### PR TITLE
Add Rust integrity tests (account, transaction, block)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1334,12 +1334,14 @@ version = "0.0.2"
 dependencies = [
  "async-stream",
  "bs58",
+ "chrono",
  "futures",
  "futures-channel",
  "futures-util",
  "prost 0.12.6",
  "prost-types 0.12.6",
  "rand 0.8.5",
+ "reqwest",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1522,6 +1524,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1971,6 +1986,23 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "native-tls"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -2609,10 +2641,12 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.32",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -2624,6 +2658,7 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
@@ -2713,7 +2748,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -2802,6 +2837,19 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -4298,6 +4346,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -31,6 +31,20 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde_json = "1.0"
 uuid = { version = "1.7.0", features = ["v4"] }
+chrono = { version = "0.4", features = ["serde", "clock"] }
+reqwest = { version = "0.11", features = ["json", "gzip", "rustls-tls"] }
 
 [build-dependencies]
 tonic-build = "0.10.2"
+
+[[bin]]
+name = "account_integrity_test"
+path = "test/account_integrity.rs"
+
+[[bin]]
+name = "transaction_integrity_test"
+path = "test/transaction_integrity.rs"
+
+[[bin]]
+name = "block_integrity_test"
+path = "test/block_integrity.rs"

--- a/rust/test/account_integrity.rs
+++ b/rust/test/account_integrity.rs
@@ -1,0 +1,221 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use futures_util::StreamExt;
+use helius_laserstream::{
+    grpc::{
+        CommitmentLevel, SubscribeRequest, SubscribeRequestAccountsDataSlice,
+        SubscribeRequestFilterAccounts,
+        subscribe_update::UpdateOneof,
+    },
+    subscribe, LaserstreamConfig,
+};
+use yellowstone_grpc_client::{ClientTlsConfig, GeyserGrpcClient};
+use bs58;
+use tracing::{error, warn};
+use std::io::{self, Write};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .with_target(false)
+        .init();    
+
+    // ---- Configuration ----
+    const ACCOUNTS: [&str; 2] = [
+        "pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA", // Pump AMM program
+        "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",   // SPL Token program
+    ];
+
+    let laser_cfg = LaserstreamConfig {
+        api_key: "".to_string(),
+        endpoint: "".to_string(),
+        ..Default::default()
+    };
+
+    let yellowstone_endpoint = "".to_string();
+    let yellowstone_token = "".to_string();
+
+    // ---- Subscription Request ----
+    let mut accounts_map = HashMap::new();
+    accounts_map.insert(
+        "tracked".to_string(),
+        SubscribeRequestFilterAccounts {
+            account: ACCOUNTS.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        },
+    );
+
+    let subscribe_req = SubscribeRequest {
+        accounts: accounts_map,
+        commitment: Some(CommitmentLevel::Confirmed as i32),
+        accounts_data_slice: Vec::<SubscribeRequestAccountsDataSlice>::new(),
+        ..Default::default()
+    };
+
+    // ---- Shared State ----
+    #[derive(Default, Clone)]
+    struct Seen { slot_ls: Option<u64>, slot_ys: Option<u64> }
+
+    let state: Arc<Mutex<HashMap<String, Seen>>> = Arc::new(Mutex::new(HashMap::new()));
+    let latest_ls: Arc<Mutex<HashMap<String, String>>> = Arc::new(Mutex::new(HashMap::new()));
+    let latest_ys: Arc<Mutex<HashMap<String, String>>> = Arc::new(Mutex::new(HashMap::new()));
+
+    let mut handles = Vec::new();
+
+    // ---- Laserstream Task ----
+    {
+        let req = subscribe_req.clone();
+        let state = Arc::clone(&state);
+        let latest_ls = Arc::clone(&latest_ls);
+        let handle = tokio::spawn(async move {
+            let mut stream = subscribe(laser_cfg, req);
+            futures::pin_mut!(stream);
+            while let Some(res) = stream.next().await {
+                match res {
+                    Ok(update) => {
+                        if let Some(UpdateOneof::Account(acc)) = update.update_oneof.as_ref() {
+                            // Extract key and slot
+                            if let (Some(account_msg), slot) = (acc.account.as_ref(), acc.slot) {
+                                let key_b58 = bs58::encode(&account_msg.pubkey).into_string();
+                                // Update state
+                                {
+                                    let mut st = state.lock().await;
+                                    let entry = st.entry(key_b58.clone()).or_default();
+                                    entry.slot_ls = Some(slot);
+                                }
+                                // Store serialised update for comparison
+                                {
+                                    let mut map = latest_ls.lock().await;
+                                    let key_b58_copy = key_b58.clone();
+                                    map.insert(key_b58_copy, format!("{:?}", update));
+                                }
+                                println!("[LS] key={} slot={}", key_b58, slot);
+                                io::stdout().flush().ok();
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        error!("LASERSTREAM error: {}", e);
+                    }
+                }
+            }
+        });
+        handles.push(handle);
+    }
+
+    // ---- Yellowstone Task ----
+    {
+        let req = subscribe_req.clone();
+        let state = Arc::clone(&state);
+        let latest_ys = Arc::clone(&latest_ys);
+        let handle = tokio::spawn(async move {
+            // Build client
+            let mut builder = GeyserGrpcClient::build_from_shared(yellowstone_endpoint)
+                .unwrap()
+                .x_token(Some(yellowstone_token))
+                .unwrap()
+                .max_decoding_message_size(1_000_000_000)
+                .tls_config(ClientTlsConfig::new().with_enabled_roots())
+                .unwrap()
+                .connect()
+                .await
+                .unwrap();
+            let (_sender, mut stream) = builder.subscribe_with_request(Some(req)).await.unwrap();
+
+            while let Some(result) = stream.next().await {
+                match result {
+                    Ok(update) => {
+                        if let Some(UpdateOneof::Account(acc)) = update.update_oneof.as_ref() {
+                            if let (Some(account_msg), slot) = (acc.account.as_ref(), acc.slot) {
+                                let key_b58 = bs58::encode(&account_msg.pubkey).into_string();
+                                {
+                                    let mut st = state.lock().await;
+                                    let entry = st.entry(key_b58.clone()).or_default();
+                                    entry.slot_ys = Some(slot);
+                                }
+                                {
+                                    let mut map = latest_ys.lock().await;
+                                    let key_b58_copy = key_b58.clone();
+                                    map.insert(key_b58_copy, format!("{:?}", update));
+                                }
+                                println!("[YS] key={} slot={}", key_b58, slot);
+                                io::stdout().flush().ok();
+                            }
+                        }
+                    }
+                    Err(e) => warn!("YELLOWSTONE stream error: {}", e),
+                }
+            }
+        });
+        handles.push(handle);
+    }
+
+    // ---- Integrity Check Task ----
+    {
+        const INTERVAL_MS: u64 = 30_000;
+        const SLOT_LAG: u64 = 3000;
+        let state = Arc::clone(&state);
+        let latest_ls = Arc::clone(&latest_ls);
+        let latest_ys = Arc::clone(&latest_ys);
+        let handle = tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(std::time::Duration::from_millis(INTERVAL_MS));
+            loop {
+                ticker.tick().await;
+                let now = chrono::Utc::now().to_rfc3339();
+
+                let st_guard = state.lock().await;
+                let ls_guard = latest_ls.lock().await;
+                let ys_guard = latest_ys.lock().await;
+
+                let all_keys: HashSet<String> = ls_guard.keys().chain(ys_guard.keys()).cloned().collect();
+
+                let mut missing_ls = Vec::new();
+                let mut missing_ys = Vec::new();
+                let mut mismatched = Vec::new();
+
+                for k in all_keys {
+                    let ls_bytes = ls_guard.get(&k);
+                    let ys_bytes = ys_guard.get(&k);
+                    let slots = st_guard.get(&k).cloned().unwrap_or_default();
+
+                    let ls_slot = slots.slot_ls;
+                    let ys_slot = slots.slot_ys;
+
+                    if ls_bytes.is_none() {
+                        missing_ls.push(k.clone());
+                        continue;
+                    }
+                    if ys_bytes.is_none() {
+                        if let (Some(ls), Some(ys)) = (ls_slot, ys_slot) {
+                            if ls - ys > SLOT_LAG {
+                                missing_ys.push(k.clone());
+                            }
+                        }
+                        continue;
+                    }
+
+                    // compare bytes only when slots match
+                    if ls_slot != ys_slot {
+                        continue;
+                    }
+                    if ls_bytes != ys_bytes {
+                        mismatched.push(k.clone());
+                    }
+                }
+
+                println!("[{}] Integrity: missing LS={} missing YS={} mismatched={}", now, missing_ls.len(), missing_ys.len(), mismatched.len());
+                for k in &missing_ls { error!("ACCOUNT MISSING IN LASERSTREAM {}", k); }
+                for k in &missing_ys { error!("ACCOUNT MISSING IN YELLOWSTONE {}", k); }
+                for k in &mismatched { error!("ACCOUNT PAYLOAD MISMATCH {}", k); }
+            }
+        });
+        handles.push(handle);
+    }
+
+    // ---- Wait forever ----
+    futures::future::join_all(handles).await;
+
+    Ok(())
+} 

--- a/rust/test/block_integrity.rs
+++ b/rust/test/block_integrity.rs
@@ -1,0 +1,116 @@
+use helius_laserstream::{
+    grpc::{
+        CommitmentLevel, SubscribeRequest, SubscribeRequestFilterSlots,
+        subscribe_update::UpdateOneof,
+    },
+    subscribe, LaserstreamConfig,
+};
+use tokio_stream::StreamExt;
+use reqwest::Client;
+use serde_json::json;
+use tracing::{error, warn};
+use std::io::{self, Write};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .with_target(false)
+        .init();
+
+    let cfg = LaserstreamConfig {
+        api_key: "".to_string(),
+        endpoint: "".to_string(),
+        ..Default::default()
+    };
+
+    let mut slots_map = std::collections::HashMap::new();
+    slots_map.insert(
+        "slotSubscribe".to_string(),
+        SubscribeRequestFilterSlots {
+            filter_by_commitment: Some(true),
+            interslot_updates: Some(false),
+            ..Default::default()
+        },
+    );
+
+    let req = SubscribeRequest {
+        slots: slots_map,
+        commitment: Some(CommitmentLevel::Confirmed as i32),
+        ..Default::default()
+    };
+
+    let rpc_endpoint = "https://mainnet.helius-rpc.com";
+
+    let client = Client::builder().gzip(true).build()?;
+
+    let mut last_slot: Option<u64> = None;
+
+    println!("Starting block integrity test. Subscribing to slots…");
+
+    let api_key_clone = cfg.api_key.clone();
+    let mut stream = subscribe(cfg, req);
+    futures::pin_mut!(stream);
+
+    while let Some(res) = stream.next().await {
+        match res {
+            Ok(update) => {
+                if let Some(UpdateOneof::Slot(slot_update)) = update.update_oneof {
+                    let current_slot = slot_update.slot;
+                    if let Some(last) = last_slot {
+                        if current_slot != last + 1 {
+                            // Iterate through gap slots
+                            for missing in (last + 1)..current_slot {
+                                if block_exists(&client, rpc_endpoint, &api_key_clone, missing).await? {
+                                    error!("ERROR: Missed slot {} – block exists but was not received.", missing);
+                                } else {
+                                    println!("Skipped slot {} (no block produced)", missing);
+                                    io::stdout().flush().ok();
+                                }
+                            }
+                        }
+                    }
+                    println!("Received slot: {}", current_slot);
+                    io::stdout().flush().ok();
+                    last_slot = Some(current_slot);
+                }
+            }
+            Err(e) => {
+                warn!("Subscription error: {}", e);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn block_exists(client: &Client, endpoint: &str, api_key: &str, slot: u64) -> Result<bool, Box<dyn std::error::Error>> {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getBlock",
+        "params": [
+            slot,
+            {
+                "encoding": "json",
+                "transactionDetails": "full",
+                "rewards": false,
+                "maxSupportedTransactionVersion": 0
+            }
+        ]
+    });
+
+    let resp = client.post(format!("{}?api-key={}", endpoint, api_key))
+        .json(&body)
+        .send()
+        .await?;
+
+    let json_resp: serde_json::Value = resp.json().await?;
+    if let Some(error_obj) = json_resp.get("error") {
+        if error_obj.get("code") == Some(&serde_json::Value::from(-32007)) {
+            // Slot was skipped – no block expected
+            return Ok(false);
+        }
+    }
+    Ok(true)
+} 

--- a/rust/test/transaction_integrity.rs
+++ b/rust/test/transaction_integrity.rs
@@ -1,0 +1,253 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use helius_laserstream::{
+    grpc::{
+        CommitmentLevel, SubscribeRequest, SubscribeRequestFilterTransactions, subscribe_update::UpdateOneof,
+    },
+    subscribe, LaserstreamConfig,
+};
+use yellowstone_grpc_client::{ClientTlsConfig, GeyserGrpcClient};
+use tokio_stream::StreamExt;
+use tracing::{error, info, warn};
+use bs58;
+use std::io::{self, Write};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .with_target(false)
+        .init();
+
+    const PUMP_PROGRAM: &str = "pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA";
+
+    let laser_cfg = LaserstreamConfig {
+        api_key: "".to_string(),
+        endpoint: "".to_string(),
+        ..Default::default()
+    };
+
+    let yellowstone_endpoint = "".to_string();
+    let yellowstone_token = "".to_string();
+
+    // --- Subscription Request ---
+    let mut tx_filter_map = HashMap::new();
+    tx_filter_map.insert(
+        "client".to_string(),
+        SubscribeRequestFilterTransactions {
+            account_include: vec![PUMP_PROGRAM.to_string()],
+            vote: Some(false),
+            failed: Some(false),
+            ..Default::default()
+        },
+    );
+
+    let subscribe_req = SubscribeRequest {
+        transactions: tx_filter_map,
+        commitment: Some(CommitmentLevel::Confirmed as i32),
+        ..Default::default()
+    };
+
+    // ---- Shared State ----
+    let ls_by_slot: Arc<Mutex<HashMap<u64, HashSet<String>>>> = Arc::new(Mutex::new(HashMap::new()));
+    let ys_by_slot: Arc<Mutex<HashMap<u64, HashSet<String>>>> = Arc::new(Mutex::new(HashMap::new()));
+    let max_slot_ls = Arc::new(Mutex::new(0u64));
+    let max_slot_ys = Arc::new(Mutex::new(0u64));
+
+    // For display and match when both slots known
+    let status_map: Arc<Mutex<HashMap<String, (Option<u64>, Option<u64>)>>> = Arc::new(Mutex::new(HashMap::new()));
+
+    // Counters for periodic report
+    let new_ls = Arc::new(Mutex::new(0u64));
+    let new_ys = Arc::new(Mutex::new(0u64));
+    let err_ls = Arc::new(Mutex::new(0u64));
+    let err_ys = Arc::new(Mutex::new(0u64));
+
+    // --- Laserstream Task ---
+    {
+        let req = subscribe_req.clone();
+        let ls_by_slot = Arc::clone(&ls_by_slot);
+        let max_slot_ls = Arc::clone(&max_slot_ls);
+        let new_ls_counter = Arc::clone(&new_ls);
+        let status_map = Arc::clone(&status_map);
+        let err_ls_counter = Arc::clone(&err_ls);
+        tokio::spawn(async move {
+            let mut stream = subscribe(laser_cfg, req);
+            futures::pin_mut!(stream);
+            while let Some(res) = stream.next().await {
+                match res {
+                    Ok(update) => {
+                        if let Some(UpdateOneof::Transaction(tx)) = update.update_oneof.as_ref() {
+                            if let Some(info) = tx.transaction.as_ref() {
+                                // Extract signature (bytes) & slot
+                                let sig_bytes: &[u8] = &info.signature;
+                                let sig_str = bs58::encode(sig_bytes).into_string();
+                                let slot = tx.slot;
+
+                                {
+                                    let mut map = ls_by_slot.lock().await;
+                                    map.entry(slot).or_default().insert(sig_str.clone());
+                                }
+                                {
+                                    let mut m = max_slot_ls.lock().await;
+                                    if slot > *m { *m = slot; }
+                                }
+                                {
+                                    let mut c = new_ls_counter.lock().await; *c += 1; }
+                                {
+                                    let mut st = status_map.lock().await;
+                                    let entry = st.entry(sig_str.clone()).or_insert((None, None));
+                                    entry.0 = Some(slot);
+                                    if entry.0.is_some() && entry.1.is_some() {
+                                        info!("MATCH {}  LS_slot={}  YS_slot={}", sig_str, slot, entry.1.unwrap());
+                                        st.remove(&sig_str);
+                                        println!("[LS] sig={} slot={}", sig_str, slot);
+                                        io::stdout().flush().ok();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!("LASERSTREAM error: {}", e);
+                        *err_ls_counter.lock().await += 1;
+                    }
+                }
+            }
+        });
+    }
+
+    // --- Yellowstone Task ---
+    {
+        let req = subscribe_req.clone();
+        let ys_by_slot = Arc::clone(&ys_by_slot);
+        let max_slot_ys = Arc::clone(&max_slot_ys);
+        let new_ys_counter = Arc::clone(&new_ys);
+        let status_map = Arc::clone(&status_map);
+        let err_ys_counter = Arc::clone(&err_ys);
+        tokio::spawn(async move {
+            let mut builder = GeyserGrpcClient::build_from_shared(yellowstone_endpoint)
+                .unwrap()
+                .x_token(Some(yellowstone_token))
+                .unwrap()
+                .max_decoding_message_size(1_000_000_000)
+                .tls_config(ClientTlsConfig::new().with_enabled_roots())
+                .unwrap()
+                .connect()
+                .await
+                .unwrap();
+
+            let (_sender, mut stream) = builder.subscribe_with_request(Some(req)).await.unwrap();
+
+            while let Some(res) = stream.next().await {
+                match res {
+                    Ok(update) => {
+                        if let Some(UpdateOneof::Transaction(tx)) = update.update_oneof.as_ref() {
+                            if let Some(info) = tx.transaction.as_ref() {
+                                let sig_bytes: &[u8] = &info.signature;
+                                let sig_str = bs58::encode(sig_bytes).into_string();
+                                let slot = tx.slot;
+
+                                {
+                                    let mut map = ys_by_slot.lock().await;
+                                    map.entry(slot).or_default().insert(sig_str.clone());
+                                }
+                                {
+                                    let mut m = max_slot_ys.lock().await; if slot > *m { *m = slot; }
+                                }
+                                {
+                                    let mut c = new_ys_counter.lock().await; *c += 1; }
+                                {
+                                    let mut st = status_map.lock().await;
+                                    let entry = st.entry(sig_str.clone()).or_insert((None, None));
+                                    entry.1 = Some(slot);
+                                    if entry.0.is_some() && entry.1.is_some() {
+                                        info!("MATCH {}  LS_slot={}  YS_slot={}", sig_str, entry.0.unwrap(), slot);
+                                        st.remove(&sig_str);
+                                        println!("[YS] sig={} slot={}", sig_str, slot);
+                                        io::stdout().flush().ok();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!("YELLOWSTONE error: {}", e);
+                        *err_ys_counter.lock().await += 1;
+                    }
+                }
+            }
+        });
+    }
+
+    // --- Integrity Check Task ---
+    {
+        const SLOT_LAG: u64 = 3000;
+        const INTERVAL_MS: u64 = 30_000;
+        let ls_by_slot = Arc::clone(&ls_by_slot);
+        let ys_by_slot = Arc::clone(&ys_by_slot);
+        let max_slot_ls = Arc::clone(&max_slot_ls);
+        let max_slot_ys = Arc::clone(&max_slot_ys);
+        let new_ls = Arc::clone(&new_ls);
+        let new_ys = Arc::clone(&new_ys);
+        let err_ls = Arc::clone(&err_ls);
+        let err_ys = Arc::clone(&err_ys);
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(std::time::Duration::from_millis(INTERVAL_MS));
+            loop {
+                ticker.tick().await;
+                let ready_slot = {
+                    let a = *max_slot_ls.lock().await;
+                    let b = *max_slot_ys.lock().await;
+                    a.min(b).saturating_sub(SLOT_LAG)
+                };
+
+                let mut total_missing_ls = 0usize;
+                let mut total_missing_ys = 0usize;
+                let mut processed_slots = 0usize;
+
+                let mut ls_map = ls_by_slot.lock().await;
+                let mut ys_map = ys_by_slot.lock().await;
+
+                let slots: HashSet<u64> = ls_map.keys().chain(ys_map.keys()).cloned().collect();
+
+                for slot in slots {
+                    if slot > ready_slot { continue; }
+                    processed_slots += 1;
+                    let set_ls = ls_map.remove(&slot).unwrap_or_default();
+                    let set_ys = ys_map.remove(&slot).unwrap_or_default();
+                    let missing_ls: HashSet<_> = set_ys.difference(&set_ls).cloned().collect();
+                    let missing_ys: HashSet<_> = set_ls.difference(&set_ys).cloned().collect();
+
+                    if !missing_ls.is_empty() || !missing_ys.is_empty() {
+                        error!("[INTEGRITY] transaction_mismatch slot={} missing Laserstream={} missing Yellowstone={}", slot, missing_ls.len(), missing_ys.len());
+                        for sig in &missing_ls { error!("SIGNATURE MISSING IN LASERSTREAM {} (YS_slot={})", sig, slot); }
+                        for sig in &missing_ys { error!("SIGNATURE MISSING IN YELLOWSTONE {} (LS_slot={})", sig, slot); }
+                    }
+
+                    total_missing_ls += missing_ls.len();
+                    total_missing_ys += missing_ys.len();
+                }
+
+                let now = chrono::Utc::now().to_rfc3339();
+                let ls_new = *new_ls.lock().await;
+                let ys_new = *new_ys.lock().await;
+                let err_l = *err_ls.lock().await;
+                let err_y = *err_ys.lock().await;
+
+                println!("[{}] laserstream+{} yellowstone+{} processedSlots:{} missingLS:{} missingYS:{} LS_errors:{} YS_errors:{}", now, ls_new, ys_new, processed_slots, total_missing_ls, total_missing_ys, err_l, err_y);
+
+                *new_ls.lock().await = 0;
+                *new_ys.lock().await = 0;
+            }
+        });
+    }
+
+    println!("Starting transaction integrity test …");
+
+    // Keep alive indefinitely
+    futures::future::pending::<()>().await;
+
+    Ok(())
+} 


### PR DESCRIPTION
Adds three standalone binaries under `rust/test`:

1. `account_integrity.rs` – compares account updates from Laserstream vs Yellowstone.
2. `transaction_integrity.rs` – reconciles Pump-program transactions across both streams.
3. `block_integrity.rs` – checks slot continuity, detects missed/ skipped blocks.

Each test logs live data, highlights mismatches, and requires only env-supplied creds.
