### PR TITLE
Rust account test bug fixes

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1343,6 +1343,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "serde_json",
+ "sha2 0.10.8",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = "1.0"
 uuid = { version = "1.7.0", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde", "clock"] }
 reqwest = { version = "0.11", features = ["json", "gzip", "rustls-tls"] }
+sha2 = "0.10"
 
 [build-dependencies]
 tonic-build = "0.10.2"


### PR DESCRIPTION
Fix integrity test’s false “ACCOUNT PAYLOAD MISMATCH” alerts.

Bug: we compared the last Laserstream vs Yellowstone payload every 30s without ensuring the slot had finished, so intra-slot writes made the two latest updates legitimately differ.

Fix: track highest slot on each feed, and only compare records whose slot ≤ min(maxLS,maxYS) – 3000 and where both slots match—mirroring the TS test. Replaced raw-string check with SHA-256 hash of `data+lamports` to ignore volatile fields.

Also cleaned up cloning of max-slot mutexes.