### PR TITLE
Reconnecting from last confirmed slot

### DIFF
--- a/javascript/test/account-integrity-test.ts
+++ b/javascript/test/account-integrity-test.ts
@@ -7,9 +7,9 @@ const ACCOUNTS = [
   'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA', // SPL Token program
 ];
 
-const laserstreamCfg: LaserstreamConfig = {
-  apiKey: '',
-  endpoint: ''
+const config: LaserstreamConfig = {
+  apiKey: process.env.LASER_API_KEY || '',
+  endpoint: process.env.LASER_ENDPOINT || ''
 };
 
 //Yellowstone node for comparing with Laserstream
@@ -27,7 +27,7 @@ const subscribeReq: any = {
     },
   },
   accountsDataSlice: [],
-  commitment: CommitmentLevel.CONFIRMED,
+  commitment: CommitmentLevel.PROCESSED,
   slots: {},
   transactions: {},
   transactionsStatus: {},
@@ -89,7 +89,7 @@ function normaliseAccountUpdate(u: any): any {
 
 async function startLaserstream() {
   await subscribe(
-    laserstreamCfg,
+    config,
     subscribeReq,
     (u) => {
       const { key, slot } = extractKeyAndSlot(u);

--- a/javascript/test/block-integrity-test.ts
+++ b/javascript/test/block-integrity-test.ts
@@ -4,8 +4,8 @@ import fetch from 'node-fetch';
 async function main() {
   // Configuration for the Laserstream service
   const config: LaserstreamConfig = {
-    apiKey: '', // Replace with your actual API key if needed
-    endpoint: '' // Replace with the appropriate endpoint
+    apiKey: process.env.LASER_API_KEY || '',
+    endpoint: process.env.LASER_ENDPOINT || ''
   };
 
   // Subscription request for blocks
@@ -13,7 +13,7 @@ async function main() {
   const subscriptionRequest: SubscribeRequest = {
     accounts: {},
     accountsDataSlice: [],
-    commitment: CommitmentLevel.CONFIRMED,
+    commitment: CommitmentLevel.PROCESSED,
     slots: {
         slotSubscribe: {
             filterByCommitment: true,

--- a/javascript/test/laserstreamChaosProxy.ts
+++ b/javascript/test/laserstreamChaosProxy.ts
@@ -4,7 +4,6 @@ import { randomInt } from 'crypto';
 /* dial the proxy in your test script */
 const LOCAL_PORT  = 4003;
 
-/* real plaintext Laserstream edge */
 const REMOTE_HOST = '';
 const REMOTE_PORT = 4001;
 

--- a/javascript/test/transaction-integrity-test.ts
+++ b/javascript/test/transaction-integrity-test.ts
@@ -12,8 +12,8 @@ async function main() {
 
   // Laserstream stream (under test)
   const config: LaserstreamConfig = {
-    apiKey: '',
-    endpoint: ''
+    apiKey: process.env.LASER_API_KEY || '',
+    endpoint: process.env.LASER_ENDPOINT || ''
   };
 
 
@@ -27,7 +27,7 @@ async function main() {
         failed: false
       }
     },
-    commitment: CommitmentLevel.CONFIRMED,
+    commitment: CommitmentLevel.PROCESSED,
     accounts: {},
     slots: {},
     transactionsStatus: {},

--- a/rust/test/account_integrity.rs
+++ b/rust/test/account_integrity.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let subscribe_req = SubscribeRequest {
         accounts: accounts_map,
-        commitment: Some(CommitmentLevel::Confirmed as i32),
+        commitment: Some(CommitmentLevel::Processed as i32),
         accounts_data_slice: Vec::<SubscribeRequestAccountsDataSlice>::new(),
         ..Default::default()
     };

--- a/rust/test/block_integrity.rs
+++ b/rust/test/block_integrity.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let req = SubscribeRequest {
         slots: slots_map,
-        commitment: Some(CommitmentLevel::Confirmed as i32),
+        commitment: Some(CommitmentLevel::Processed as i32),
         ..Default::default()
     };
 

--- a/rust/test/transaction_integrity.rs
+++ b/rust/test/transaction_integrity.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let subscribe_req = SubscribeRequest {
         transactions: tx_filter_map,
-        commitment: Some(CommitmentLevel::Confirmed as i32),
+        commitment: Some(CommitmentLevel::Processed as i32),
         ..Default::default()
     };
 


### PR DESCRIPTION
### Replay from the last **CONFIRMED** slot

#### What changed  
• Two pointers are maintained: `trackedSlot` (latest processed slot) and `confirmedSlot` (latest slot whose status ≥ CONFIRMED).  
• On reconnect the client sets `fromSlot = confirmedSlot` (falls back to `trackedSlot` until the first confirmation arrives).  
• Live data is forwarded exactly as requested; internal tracker messages are filtered out.  

#### Why  
Replaying from the last processed slot could restart on a temporary fork or require an arbitrary rewind. Anchoring on the most recent confirmed slot guarantees the replay pointer is on the canonical chain while adding only ~1.5 s of duplicate overlap.

#### Edge-cases
• User subscribes only to PROCESSED slots – internal tracker still captures confirmations, user stream unchanged.  
• The user disables `interslotUpdates`; the tracker enforces its own `true` flag, so confirmation updates are always seen.  
• Internal tracker uses a unique label; caller never receives higher-commitment duplicates.  
• Startup disconnect before first confirmation – client safely falls back to the last processed slot; fork risk limited to that initial window.  
• Caller sets global `commitment = FINALIZED`. Our logic still works; status 2 (FINALIZED) advances both `trackedSlot` and `confirmedSlot`, replay still safe.
• Caller supplies `slots` but later removes it on reconnect by sending an empty map.  We inject our tracker **each** time we build the request, so it’s re-added automatically.
• Caller sets `filterByCommitment:false` in their own filter, hoping to receive *all* commitment transitions. Fine; they’ll now see duplicates at different statuses. Our filtering doesn’t affect that stream.
• Caller sets `fromSlot` themselves on reconnect. Our logic mutates `fromSlot` **after** we clone their request, so our value overrides theirs; replay safety is preserved.
• Slot transition never reaches CONFIRMED because the cluster halts. `confirmedSlot` stays 0; we fall back to `trackedSlot` and behave exactly like the old logic—no worse than before.

None of these scenarios breaks the new mechanism; worst-case, it degrades gracefully to the old “processed” behaviour.