### PR TITLE
Fix self-dependency in JS package

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@triton-one/yellowstone-grpc": "^4.0.0",
     "bs58": "^5.0.0",
-    "helius-laserstream": "^0.0.7",
     "node-fetch": "^3.3.2",
     "uuid": "^9.0.0"
   },


### PR DESCRIPTION
## Summary
- remove accidental self-dependency from `javascript/package.json`

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: missing type definitions)*
- `cargo test` *(fails: couldn't access crates.io)*

------
https://chatgpt.com/codex/tasks/task_b_684f136abee48323a362f4d0c7169d02