### PR TITLE
gRPC settings for performance optimisations

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1330,7 +1330,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "helius-laserstream"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-stream",
  "bs58",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helius-laserstream"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 authors = ["Helius <support@helius.xyz>"]
 description = "Rust client for Helius LaserStream gRPC with robust reconnection and slot tracking"


### PR DESCRIPTION
These gRPC setting significantly reduced latency for the ls Rust client.