### PR TITLE
gRPC Channel Options and Bidirectional Streaming Support

### DIFF
--- a/go/examples/account-sub.go
+++ b/go/examples/account-sub.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	laserstream "laserstream-go-client"
+	laserstream "github.com/helius-labs/laserstream-sdk/go"
 
 	"github.com/joho/godotenv"
 )
@@ -28,7 +28,6 @@ func main() {
 	clientConfig := laserstream.LaserstreamConfig{
 		Endpoint: endpoint,
 		APIKey:   apiKey,
-		Insecure: false,
 	}
 
 	commitmentLevel := laserstream.CommitmentLevel_PROCESSED
@@ -60,5 +59,5 @@ func main() {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	<-sigChan
 
-	client.Close()
+	client.Unsubscribe()
 }

--- a/go/examples/accounts-data-slice-sub.go
+++ b/go/examples/accounts-data-slice-sub.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	laserstream "laserstream-go-client"
+	laserstream "github.com/helius-labs/laserstream-sdk/go"
 
 	"github.com/joho/godotenv"
 )
@@ -28,7 +28,7 @@ func main() {
 	clientConfig := laserstream.LaserstreamConfig{
 		Endpoint: endpoint,
 		APIKey:   apiKey,
-		Insecure: false,
+		
 	}
 
 	commitmentLevel := laserstream.CommitmentLevel_PROCESSED
@@ -73,5 +73,5 @@ func main() {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	<-sigChan
 
-	client.Close()
+	client.Unsubscribe()
 }

--- a/go/examples/block-meta-sub.go
+++ b/go/examples/block-meta-sub.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	laserstream "laserstream-go-client"
+	laserstream "github.com/helius-labs/laserstream-sdk/go"
 
 	"github.com/joho/godotenv"
 )
@@ -28,7 +28,7 @@ func main() {
 	clientConfig := laserstream.LaserstreamConfig{
 		Endpoint: endpoint,
 		APIKey:   apiKey,
-		Insecure: false,
+		
 	}
 
 	commitmentLevel := laserstream.CommitmentLevel_PROCESSED
@@ -58,5 +58,5 @@ func main() {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	<-sigChan
 
-	client.Close()
+	client.Unsubscribe()
 }

--- a/go/examples/block-sub.go
+++ b/go/examples/block-sub.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	laserstream "laserstream-go-client"
+	laserstream "github.com/helius-labs/laserstream-sdk/go"
 
 	"github.com/joho/godotenv"
 )
@@ -28,7 +28,7 @@ func main() {
 	clientConfig := laserstream.LaserstreamConfig{
 		Endpoint: endpoint,
 		APIKey:   apiKey,
-		Insecure: false,
+		
 	}
 
 	commitmentLevel := laserstream.CommitmentLevel_PROCESSED
@@ -58,5 +58,5 @@ func main() {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	<-sigChan
 
-	client.Close()
+	client.Unsubscribe()
 }

--- a/go/examples/channel-options-example.go
+++ b/go/examples/channel-options-example.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	laserstream "github.com/helius-labs/laserstream-sdk/go"
+
+	"github.com/joho/godotenv"
+)
+
+func main() {
+	// Get configuration from environment
+	godotenv.Load("../.env")
+
+	endpoint := os.Getenv("LASERSTREAM_PRODUCTION_ENDPOINT")
+	if endpoint == "" {
+		log.Fatal("LASERSTREAM_PRODUCTION_ENDPOINT required")
+	}
+	apiKey := os.Getenv("LASERSTREAM_PRODUCTION_API_KEY")
+	if apiKey == "" {
+		log.Fatal("LASERSTREAM_PRODUCTION_API_KEY required")
+	}
+
+	// Create custom channel options
+	channelOptions := &laserstream.ChannelOptions{
+		// Connection timeouts
+		ConnectTimeoutSecs:    20, // 20 seconds instead of default 10
+		MinConnectTimeoutSecs: 15, // 15 seconds minimum connect timeout
+
+		// Message size limits
+		MaxRecvMsgSize: 2 * 1024 * 1024 * 1024, // 2GB instead of default 1GB
+		MaxSendMsgSize: 64 * 1024 * 1024,       // 64MB instead of default 32MB
+
+		// Keepalive settings
+		KeepaliveTimeSecs:    15, // 15 seconds instead of default 30
+		KeepaliveTimeoutSecs: 10, // 10 seconds instead of default 5
+		PermitWithoutStream:  true,
+
+		// Window sizes for flow control
+		InitialWindowSize:     8 * 1024 * 1024,  // 8MB instead of default 4MB
+		InitialConnWindowSize: 16 * 1024 * 1024, // 16MB instead of default 8MB
+
+		// Buffer settings
+		WriteBufferSize: 128 * 1024, // 128KB instead of default 64KB
+		ReadBufferSize:  128 * 1024, // 128KB read buffer
+
+		// Compression settings
+		UseCompression: true, // Enable gzip compression
+	}
+
+	// Create client configuration with custom channel options
+	maxReconnectAttempts := 5
+	config := laserstream.LaserstreamConfig{
+		Endpoint:             endpoint,
+		APIKey:               apiKey,
+		MaxReconnectAttempts: &maxReconnectAttempts,
+		ChannelOptions:       channelOptions,
+	}
+
+	// Create client
+	client := laserstream.NewClient(config)
+
+	// Create a simple slot subscription request
+	req := &laserstream.SubscribeRequest{
+		Slots: map[string]*laserstream.SubscribeRequestFilterSlots{
+			"client": {},
+		},
+	}
+
+	fmt.Println("Subscribing with custom channel options...")
+	fmt.Println("- Connect timeout: 20s")
+	fmt.Println("- Max receive message size: 2GB")
+	fmt.Println("- Keepalive interval: 15s")
+	fmt.Println("- Initial stream window: 8MB")
+	fmt.Println("- Write buffer size: 128KB")
+	fmt.Println("- Compression: gzip enabled")
+
+	// Data handler
+	dataHandler := func(update *laserstream.SubscribeUpdate) {
+		switch u := update.UpdateOneof.(type) {
+		case *laserstream.SubscribeUpdate_Slot:
+			fmt.Printf("Slot update: %d (parent: %d)\n", u.Slot.Slot, u.Slot.Parent)
+		default:
+			fmt.Printf("Received update: %T\n", u)
+		}
+	}
+
+	// Error handler
+	errorHandler := func(err error) {
+		log.Printf("Stream error: %v", err)
+	}
+
+	// Subscribe
+	if err := client.Subscribe(req, dataHandler, errorHandler); err != nil {
+		log.Fatalf("Failed to subscribe: %v", err)
+	}
+
+	// Wait for interrupt
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	<-sigChan
+
+	fmt.Println("\nShutting down...")
+	client.Unsubscribe()
+}

--- a/go/examples/entry-sub.go
+++ b/go/examples/entry-sub.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	laserstream "laserstream-go-client"
+	laserstream "github.com/helius-labs/laserstream-sdk/go"
 
 	"github.com/joho/godotenv"
 )
@@ -28,7 +28,7 @@ func main() {
 	clientConfig := laserstream.LaserstreamConfig{
 		Endpoint: endpoint,
 		APIKey:   apiKey,
-		Insecure: false,
+		
 	}
 
 	commitmentLevel := laserstream.CommitmentLevel_PROCESSED
@@ -58,5 +58,5 @@ func main() {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	<-sigChan
 
-	client.Close()
+	client.Unsubscribe()
 }

--- a/go/examples/slot-sub.go
+++ b/go/examples/slot-sub.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	laserstream "laserstream-go-client"
+	laserstream "github.com/helius-labs/laserstream-sdk/go"
 
 	"github.com/joho/godotenv"
 )
@@ -28,7 +28,7 @@ func main() {
 	clientConfig := laserstream.LaserstreamConfig{
 		Endpoint: endpoint,
 		APIKey:   apiKey,
-		Insecure: false,
+		
 	}
 
 	commitmentLevel := laserstream.CommitmentLevel_PROCESSED
@@ -61,5 +61,5 @@ func main() {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	<-sigChan
 
-	client.Close()
+	client.Unsubscribe()
 }

--- a/go/examples/stream-write-example.go
+++ b/go/examples/stream-write-example.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	laserstream "github.com/helius-labs/laserstream-sdk/go"
+	"github.com/joho/godotenv"
+)
+
+func main() {
+	// Get configuration from environment
+	godotenv.Load("../.env")
+
+	endpoint := os.Getenv("LASERSTREAM_PRODUCTION_ENDPOINT")
+	if endpoint == "" {
+		log.Fatal("LASERSTREAM_PRODUCTION_ENDPOINT required")
+	}
+	apiKey := os.Getenv("LASERSTREAM_PRODUCTION_API_KEY")
+	if apiKey == "" {
+		log.Fatal("LASERSTREAM_PRODUCTION_API_KEY required")
+	}
+
+	// Create client with compression enabled
+	channelOptions := &laserstream.ChannelOptions{
+		UseCompression: true,
+	}
+
+	config := laserstream.LaserstreamConfig{
+		Endpoint:       endpoint,
+		APIKey:         apiKey,
+		ChannelOptions: channelOptions,
+	}
+
+	// Create client
+	client := laserstream.NewClient(config)
+	commitmentLevel := laserstream.CommitmentLevel_FINALIZED
+
+	// Initial subscription request - just subscribe to slots
+	initialReq := &laserstream.SubscribeRequest{
+		Slots: map[string]*laserstream.SubscribeRequestFilterSlots{
+			"client": {
+				FilterByCommitment: &[]bool{true}[0],
+			},
+		},
+		Commitment: &commitmentLevel,
+	}
+
+	fmt.Println("🚀 Laserstream Bidirectional Stream Example")
+	fmt.Println("📡 Starting initial subscription to slots...")
+
+	var messageCount int32
+	var transactionAdded atomic.Bool
+	var blockAdded atomic.Bool
+
+	// Data handler
+	dataHandler := func(update *laserstream.SubscribeUpdate) {
+		count := atomic.AddInt32(&messageCount, 1)
+
+		switch u := update.UpdateOneof.(type) {
+		case *laserstream.SubscribeUpdate_Slot:
+			fmt.Printf("🎰 Slot update #%d: %d\n", count, u.Slot.Slot)
+
+			// After receiving 5 slot updates, add a transaction subscription
+			if count == 5 && transactionAdded.CompareAndSwap(false, true) {
+				fmt.Println("\n📝 Adding transaction subscription after 5 slots...")
+
+				transactionReq := &laserstream.SubscribeRequest{
+					Transactions: map[string]*laserstream.SubscribeRequestFilterTransactions{
+						"client": {
+							Vote:   &[]bool{false}[0],
+							Failed: &[]bool{false}[0],
+						},
+					},
+				}
+
+				if err := client.Write(transactionReq); err != nil {
+					fmt.Printf("❌ Failed to add transaction subscription: %v\n", err)
+				} else {
+					fmt.Println("✅ Successfully added transaction subscription")
+				}
+			}
+
+		case *laserstream.SubscribeUpdate_Transaction:
+			fmt.Printf("💸 Transaction update: %s\n", u.Transaction.Transaction.Signature)
+
+			// After receiving some transactions, add a block subscription
+			if count >= 15 && blockAdded.CompareAndSwap(false, true) {
+				fmt.Println("\n📦 Adding block subscription...")
+
+				blockReq := &laserstream.SubscribeRequest{
+					Blocks: map[string]*laserstream.SubscribeRequestFilterBlocks{
+						"client": {
+							IncludeTransactions: &[]bool{true}[0],
+							IncludeAccounts:     &[]bool{false}[0],
+							IncludeEntries:      &[]bool{false}[0],
+						},
+					},
+				}
+
+				if err := client.Write(blockReq); err != nil {
+					fmt.Printf("❌ Failed to add block subscription: %v\n", err)
+				} else {
+					fmt.Println("✅ Successfully added block subscription")
+				}
+			}
+
+		case *laserstream.SubscribeUpdate_Block:
+			txCount := 0
+			if u.Block.Transactions != nil {
+				txCount = len(u.Block.Transactions)
+			}
+			fmt.Printf("📦 Block update: slot %d, %d transactions\n", u.Block.Slot, txCount)
+
+		default:
+			fmt.Printf("📦 Received update: %T\n", u)
+		}
+
+		// Stop after 25 messages
+		if count >= 25 {
+			fmt.Println("\n🛑 Received 25 messages, shutting down...")
+			client.Unsubscribe()
+			os.Exit(0)
+		}
+	}
+
+	// Error handler
+	errorHandler := func(err error) {
+		log.Printf("Stream error: %v", err)
+	}
+
+	// Subscribe
+	if err := client.Subscribe(initialReq, dataHandler, errorHandler); err != nil {
+		log.Fatalf("Failed to subscribe: %v", err)
+	}
+
+	fmt.Println("✅ Stream started successfully")
+
+	// Wait for interrupt
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+	// Add a timeout to demonstrate the feature
+	go func() {
+		time.Sleep(60 * time.Second)
+		fmt.Println("\n⏰ Timeout reached, shutting down...")
+		sigChan <- syscall.SIGTERM
+	}()
+
+	<-sigChan
+
+	fmt.Println("\n🛑 Shutting down...")
+	client.Unsubscribe()
+}

--- a/go/examples/transaction-status-sub.go
+++ b/go/examples/transaction-status-sub.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	laserstream "laserstream-go-client"
+	laserstream "github.com/helius-labs/laserstream-sdk/go"
 
 	"github.com/joho/godotenv"
 )
@@ -28,7 +28,7 @@ func main() {
 	clientConfig := laserstream.LaserstreamConfig{
 		Endpoint: endpoint,
 		APIKey:   apiKey,
-		Insecure: false,
+		
 	}
 
 	commitmentLevel := laserstream.CommitmentLevel_PROCESSED
@@ -61,5 +61,5 @@ func main() {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	<-sigChan
 
-	client.Close()
+	client.Unsubscribe()
 }

--- a/go/examples/transaction-sub.go
+++ b/go/examples/transaction-sub.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	laserstream "laserstream-go-client"
+	laserstream "github.com/helius-labs/laserstream-sdk/go"
 
 	"github.com/joho/godotenv"
 )
@@ -28,7 +28,7 @@ func main() {
 	clientConfig := laserstream.LaserstreamConfig{
 		Endpoint: endpoint,
 		APIKey:   apiKey,
-		Insecure: false,
+		
 	}
 
 	commitmentLevel := laserstream.CommitmentLevel_PROCESSED
@@ -62,5 +62,5 @@ func main() {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	<-sigChan
 
-	client.Close()
+	client.Unsubscribe()
 }

--- a/go/test/block-integrity-test.go
+++ b/go/test/block-integrity-test.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	laserstream "laserstream-go-client"
+	laserstream "github.com/helius-labs/laserstream-sdk/go"
 
 	"github.com/joho/godotenv"
 )

--- a/go/test/internal-slot-filter-test.go
+++ b/go/test/internal-slot-filter-test.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"time"
 
-	laserstream "laserstream-go-client"
+	laserstream "github.com/helius-labs/laserstream-sdk/go"
 
 	"github.com/joho/godotenv"
 )
@@ -86,7 +86,7 @@ func main() {
 	config := laserstream.LaserstreamConfig{
 		Endpoint: endpoint,
 		APIKey:   apiKey,
-		Insecure: false,
+		
 	}
 
 	userSlotFilterID := "user-slot-test"

--- a/go/test/transaction-integrity-test.go
+++ b/go/test/transaction-integrity-test.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	laserstream "laserstream-go-client"
+	laserstream "github.com/helius-labs/laserstream-sdk/go"
 
 	"github.com/joho/godotenv"
 

--- a/javascript/Cargo.lock
+++ b/javascript/Cargo.lock
@@ -1671,6 +1671,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "futures",
+ "futures-channel",
  "futures-util",
  "napi",
  "napi-build",

--- a/javascript/Cargo.toml
+++ b/javascript/Cargo.toml
@@ -19,6 +19,7 @@ tonic = { version = "0.11", features = ["transport", "tls"] }
 bytes = "1"
 futures = "0.3"
 futures-util = "0.3"
+futures-channel = "0.3"
 parking_lot = "0.12"
 uuid = { version = "1", features = ["v4"] }
 yellowstone-grpc-client = "6.1.0"

--- a/javascript/client.d.ts
+++ b/javascript/client.d.ts
@@ -1,10 +1,37 @@
 // TypeScript declarations for Laserstream client with protobuf decoding
 
+// Channel options interface
+export interface ChannelOptions {
+  // Connection timeouts
+  connectTimeoutSecs?: number;
+  timeoutSecs?: number;
+  
+  // Message size limits
+  maxDecodingMessageSize?: number;
+  maxEncodingMessageSize?: number;
+  
+  // Keep-alive settings
+  http2KeepAliveIntervalSecs?: number;
+  keepAliveTimeoutSecs?: number;
+  keepAliveWhileIdle?: boolean;
+  
+  // Window sizes for flow control
+  initialStreamWindowSize?: number;
+  initialConnectionWindowSize?: number;
+  
+  // Performance options
+  http2AdaptiveWindow?: boolean;
+  tcpNodelay?: boolean;
+  tcpKeepaliveSecs?: number;
+  bufferSize?: number;
+}
+
 // Configuration interface
 export interface LaserstreamConfig {
   apiKey: string;
   endpoint: string;
   maxReconnectAttempts?: number;
+  channelOptions?: ChannelOptions;
 }
 
 // Subscription request interface
@@ -41,6 +68,7 @@ export interface SubscribeUpdate {
 export interface StreamHandle {
   id: string;
   cancel(): void;
+  write(request: SubscribeRequest): Promise<void>;
 }
 
 // Commitment level enum

--- a/javascript/client.js
+++ b/javascript/client.js
@@ -17,7 +17,7 @@ async function subscribe(config, request, onData, onError) {
   await ensureProtobufInitialized();
 
   // Create NAPI client instance directly
-  const napiClient = new NapiClient(config.endpoint, config.apiKey, config.maxReconnectAttempts);
+  const napiClient = new NapiClient(config.endpoint, config.apiKey, config.maxReconnectAttempts, config.channelOptions);
 
   // Wrap the callbacks to decode protobuf bytes
   const wrappedCallback = (error, updateBytes) => {

--- a/javascript/examples/channel-options-example.ts
+++ b/javascript/examples/channel-options-example.ts
@@ -1,0 +1,92 @@
+import { subscribe, CommitmentLevel, SubscribeUpdate, StreamHandle, LaserstreamConfig, ChannelOptions } from '../client';
+
+const credentials = require('../test-config');
+
+async function main() {
+  console.log('⚙️  Laserstream Channel Options Example');
+
+  // Custom channel options
+  const channelOptions: ChannelOptions = {
+    // Connection timeouts
+    connectTimeoutSecs: 20,              // 20 seconds instead of default 10
+    timeoutSecs: 60,                     // 60 seconds instead of default 30
+    
+    // Message size limits
+    maxDecodingMessageSize: 2000000000,  // 2GB instead of default 1GB
+    maxEncodingMessageSize: 64000000,    // 64MB instead of default 32MB
+    
+    // Keep-alive settings
+    http2KeepAliveIntervalSecs: 15,     // 15 seconds instead of default 30
+    keepAliveTimeoutSecs: 10,           // 10 seconds instead of default 5
+    keepAliveWhileIdle: true,
+    
+    // Window sizes for flow control
+    initialStreamWindowSize: 8388608,    // 8MB instead of default 4MB
+    initialConnectionWindowSize: 16777216, // 16MB instead of default 8MB
+    
+    // Performance options
+    http2AdaptiveWindow: true,
+    tcpNodelay: true,
+    tcpKeepaliveSecs: 30,               // 30 seconds instead of default 60
+    bufferSize: 131072,                 // 128KB instead of default 64KB
+  };
+
+  // Configuration with custom channel options
+  const config: LaserstreamConfig = {
+    apiKey: credentials.laserstreamProduction.apiKey,
+    endpoint: credentials.laserstreamProduction.endpoint,
+    maxReconnectAttempts: 5,
+    channelOptions: channelOptions
+  };
+
+  // Subscription request
+  const request = {
+    slots: {
+      client: {
+        filterByCommitment: true,
+      }
+    },
+    commitment: CommitmentLevel.CONFIRMED
+  };
+
+  console.log('📡 Subscribing with custom channel options:');
+  console.log('   - Connect timeout: 20s');
+  console.log('   - Max receive message size: 2GB');
+  console.log('   - Keep-alive interval: 15s');
+  console.log('   - Initial stream window: 8MB');
+  console.log('   - Buffer size: 128KB');
+
+  try {
+    const stream: StreamHandle = await subscribe(
+      config,
+      request,
+      // Data callback
+      async (update: SubscribeUpdate) => {
+        if (update.slot) {
+          console.log(`🎰 Slot update: ${update.slot.slot}`);
+        } else {
+          console.log('📦 Received update:', update);
+        }
+      },
+      // Error callback
+      async (error: Error) => {
+        console.error('❌ Stream error:', error);
+      }
+    );
+
+    console.log(`✅ Stream started with ID: ${stream.id}`);
+
+    // Handle graceful shutdown
+    process.on('SIGINT', async () => {
+      console.log('\n🛑 Shutting down...');
+      stream.cancel();
+      process.exit(0);
+    });
+
+  } catch (error) {
+    console.error('❌ Failed to subscribe:', error);
+    process.exit(1);
+  }
+}
+
+main().catch(console.error);

--- a/javascript/examples/stream-write-example.ts
+++ b/javascript/examples/stream-write-example.ts
@@ -1,0 +1,139 @@
+import { subscribe, CommitmentLevel, SubscribeUpdate, StreamHandle, LaserstreamConfig, SubscribeRequest } from '../client';
+import bs58 from 'bs58';
+
+const credentials = require('../test-config');
+
+async function main() {
+
+  const config: LaserstreamConfig = {
+    apiKey: credentials.laserstreamProduction.apiKey,
+    endpoint: credentials.laserstreamProduction.endpoint,
+  };
+
+  const request = {
+    accounts: {
+      "all-accounts": {
+        account: [],
+        owner: ["TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"],
+        filters: []
+      }
+    },
+    commitment: CommitmentLevel.PROCESSED,
+    slots: {},
+    transactions: {},
+    transactionsStatus: {},
+    blocks: {},
+    blocksMeta: {},
+    entry: {},
+    accountsDataSlice: [],
+  };
+
+  let message = 0;
+  // Initial subscription request
+  const stream = await subscribe(
+    config,
+    request,
+    async (update: SubscribeUpdate) => {
+      message+=1
+      if(update.account){
+      console.log('🏦 Account Update:', bs58.encode(update.account?.account?.owner))
+      }
+      console.log(message)
+      if(message == 50){
+        try{
+        stream.write({
+          accounts: {
+            "all-accounts": {
+              account: [],
+              owner: ["TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"],
+              filters: []
+            }
+          }
+        })
+        }catch(e){
+          console.error('❌ Stream error:', e)
+        }
+      }
+    },
+    async (err) => console.error('❌ Stream error:', err)
+  );
+
+  // stream.cancel();
+}
+
+main().catch(console.error);
+
+
+// import { CommitmentLevel, SubscribeUpdate, SubscribeRequest } from '@triton-one/yellowstone-grpc';
+
+// import Client from '@triton-one/yellowstone-grpc';
+// import bs58 from 'bs58';
+// import { LaserstreamConfig } from '../client';
+// import { write } from 'fs';
+
+// const credentials = require('../test-config');
+
+// async function main() {
+
+//   const client = new Client(credentials.laserstreamProduction.endpoint, credentials.laserstreamProduction.apiKey, undefined);
+
+//     const request: SubscribeRequest = {
+//     accounts: {
+//       "all-accounts": {
+//         account: [],
+//         owner: ["TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"],
+//         filters: []
+//       }
+//     },
+//     commitment: CommitmentLevel.PROCESSED,
+//     slots: {},
+//     transactions: {},
+//     transactionsStatus: {},
+//     blocks: {},
+//     blocksMeta: {},
+//     entry: {},
+//     accountsDataSlice: [],
+//   };
+
+//   let message = 0;
+//   // Initial subscription request
+//     const stream = await client.subscribe()
+
+//     stream.write(request)
+
+//     stream.on('data', (data) => {
+//       console.log('🏦 Data:', data.account?.account?.owner)
+//       message+=1
+//       if(data.account){
+//       console.log('🏦 Account Update:', bs58.encode(data.account?.account?.owner))
+//       }
+//       console.log(message)
+//       if(message == 50){
+//         try{
+//           stream.write({
+//             accounts: {
+//               "all-accounts": {
+//                 account: [],
+//                 owner: ['TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'],
+//                 filters: []
+//               }
+//             },
+//             commitment: CommitmentLevel.PROCESSED,
+//             slots: {},
+//             transactions: {},
+//             transactionsStatus: {},
+//             blocks: {},
+//             blocksMeta: {},
+//             entry: {},
+//             accountsDataSlice: []
+//           })
+//         }catch(e){
+//           console.error('❌ Stream error:', e)
+//         }
+//       }
+//     })
+
+//   // stream.cancel();
+// }
+
+// main().catch(console.error);

--- a/javascript/index.d.ts
+++ b/javascript/index.d.ts
@@ -11,10 +11,11 @@ export const enum CommitmentLevel {
   FINALIZED = 2
 }
 export declare class LaserstreamClient {
-  constructor(endpoint: string, token?: string | undefined | null, maxReconnectAttempts?: number | undefined | null)
+  constructor(endpoint: string, token?: string | undefined | null, maxReconnectAttempts?: number | undefined | null, channelOptions?: object | undefined | null)
   subscribe(request: any, callback: (error: Error | null, updateBytes: Uint8Array) => void): Promise<StreamHandle>
 }
 export declare class StreamHandle {
   id: string
   cancel(): void
+  write(request: any): void
 }

--- a/javascript/napi-src/client.rs
+++ b/javascript/napi-src/client.rs
@@ -23,6 +23,46 @@ pub struct ClientInner {
     endpoint: String,
     token: Option<String>,
     max_reconnect_attempts: u32,
+    channel_options: Option<ChannelOptions>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct ChannelOptions {
+    // Connection timeouts
+    #[serde(rename = "connectTimeoutSecs")]
+    pub connect_timeout_secs: Option<u64>,
+    #[serde(rename = "timeoutSecs")]
+    pub timeout_secs: Option<u64>,
+    
+    // Message size limits
+    #[serde(rename = "maxDecodingMessageSize")]
+    pub max_decoding_message_size: Option<usize>,
+    #[serde(rename = "maxEncodingMessageSize")]
+    pub max_encoding_message_size: Option<usize>,
+    
+    // Keep-alive settings
+    #[serde(rename = "http2KeepAliveIntervalSecs")]
+    pub http2_keep_alive_interval_secs: Option<u64>,
+    #[serde(rename = "keepAliveTimeoutSecs")]
+    pub keep_alive_timeout_secs: Option<u64>,
+    #[serde(rename = "keepAliveWhileIdle")]
+    pub keep_alive_while_idle: Option<bool>,
+    
+    // Window sizes
+    #[serde(rename = "initialStreamWindowSize")]
+    pub initial_stream_window_size: Option<u32>,
+    #[serde(rename = "initialConnectionWindowSize")]
+    pub initial_connection_window_size: Option<u32>,
+    
+    // Performance options
+    #[serde(rename = "http2AdaptiveWindow")]
+    pub http2_adaptive_window: Option<bool>,
+    #[serde(rename = "tcpNodelay")]
+    pub tcp_nodelay: Option<bool>,
+    #[serde(rename = "tcpKeepaliveSecs")]
+    pub tcp_keepalive_secs: Option<u64>,
+    #[serde(rename = "bufferSize")]
+    pub buffer_size: Option<usize>,
 }
 
 // Complete serde-based structures matching yellowstone-grpc proto exactly
@@ -145,11 +185,13 @@ impl ClientInner {
         endpoint: String,
         token: Option<String>,
         max_reconnect_attempts: Option<u32>,
+        channel_options: Option<ChannelOptions>,
     ) -> Result<Self> {
         Ok(Self {
             endpoint,
             token,
             max_reconnect_attempts: max_reconnect_attempts.unwrap_or(120),
+            channel_options,
         })
     }
 
@@ -412,6 +454,7 @@ impl ClientInner {
             subscribe_request,
             ts_callback,
             self.max_reconnect_attempts,
+            self.channel_options.clone(),
         )?);
 
         // Register stream in global registry for lifecycle management

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1030,6 +1030,45 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/helius-laserstream-darwin-arm64": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/helius-laserstream-darwin-arm64/-/helius-laserstream-darwin-arm64-0.1.2.tgz",
+      "integrity": "sha512-0TmeUpfE2LmdSfHYs9Fobdz38/Ps92tnYPAZ1u1yYBrPjFkUqzfegGjb2zeBD7rfui0HDpF0Ytj29isjUt4JRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/helius-laserstream-darwin-x64": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/helius-laserstream-darwin-x64/-/helius-laserstream-darwin-x64-0.1.2.tgz",
+      "integrity": "sha512-SjIL3PaFx4f7lyx1rKDujJp1R1gNDn7UlmQH3DsuJwdS4owcnZDnKjopvhTGKG+IHnZRA8f0XSxez2RJDxOTrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/helius-laserstream-linux-x64-gnu": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/helius-laserstream-linux-x64-gnu/-/helius-laserstream-linux-x64-gnu-0.1.2.tgz",
+      "integrity": "sha512-9LxzbTVr4RhuSvTjSMuR4TZI0tfctZl3qZk4nm3j5B2vLXzVYUX/Ixk6meGr6LDYsItBqskGYy/6Lv75dujikw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -26,6 +26,7 @@
     "example:block-sub": "ts-node examples/block-sub.ts",
     "example:block-meta-sub": "ts-node examples/block-meta-sub.ts",
     "example:entry-sub": "ts-node examples/entry-sub.ts",
+    "example:channel-options": "ts-node examples/channel-options-example.ts",
     "perf:test": "ts-node performance/pump-raydium-performance-test.ts",
     "perf:slot": "ts-node performance/slot-performance-test.ts",
     "perf:token": "ts-node performance/token-performance-test.ts",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1041,7 +1041,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "helius-laserstream"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "async-stream",
  "bs58",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -49,3 +49,7 @@ path = "test/transaction_integrity.rs"
 [[bin]]
 name = "block_integrity_test"
 path = "test/block_integrity.rs"
+
+[[bin]]
+name = "basic_usage"
+path = "examples/basic_usage.rs"

--- a/rust/examples/channel-options-example.rs
+++ b/rust/examples/channel-options-example.rs
@@ -1,0 +1,77 @@
+use helius_laserstream::{subscribe, ChannelOptions, LaserstreamConfig, SubscribeRequest, SubscribeRequestFilterSlots};
+use futures::StreamExt;
+use std::collections::HashMap;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let endpoint = std::env::var("LASERSTREAM_PRODUCTION_ENDPOINT")
+        .unwrap_or_else(|_| "".to_string());
+    let api_key = std::env::var("LASERSTREAM_PRODUCTION_API_KEY")
+        .expect("LASERSTREAM_PRODUCTION_API_KEY environment variable must be set");
+
+    // Create custom channel options
+    let channel_options = ChannelOptions {
+        // Connection timeouts
+        connect_timeout_secs: Some(20),              // 20 seconds instead of default 10
+        timeout_secs: Some(60),                      // 60 seconds instead of default 30
+        
+        // Message size limits
+        max_decoding_message_size: Some(2_000_000_000),  // 2GB instead of default 1GB
+        max_encoding_message_size: Some(64_000_000),     // 64MB instead of default 32MB
+        
+        // Keep-alive settings
+        http2_keep_alive_interval_secs: Some(15),   // 15 seconds instead of default 30
+        keep_alive_timeout_secs: Some(10),           // 10 seconds instead of default 5
+        keep_alive_while_idle: Some(true),
+        
+        // Window sizes for flow control
+        initial_stream_window_size: Some(8 * 1024 * 1024),      // 8MB instead of default 4MB
+        initial_connection_window_size: Some(16 * 1024 * 1024), // 16MB instead of default 8MB
+        
+        // Performance options
+        http2_adaptive_window: Some(true),
+        tcp_nodelay: Some(true),
+        tcp_keepalive_secs: Some(30),               // 30 seconds instead of default 60
+        buffer_size: Some(128 * 1024),               // 128KB instead of default 64KB
+    };
+
+    // Create config with custom channel options
+    let config = LaserstreamConfig::new(endpoint, api_key)
+        .with_max_reconnect_attempts(5)
+        .with_channel_options(channel_options);
+
+    // Create a simple slot subscription request
+    let mut slots_filter = HashMap::new();
+    slots_filter.insert(
+        "client".to_string(),
+        SubscribeRequestFilterSlots::default(),
+    );
+
+    let request = SubscribeRequest {
+        slots: slots_filter,
+        ..Default::default()
+    };
+
+    println!("Subscribing with custom channel options...");
+    println!("- Connect timeout: 20s");
+    println!("- Max receive message size: 2GB");
+    println!("- Keep-alive interval: 15s");
+    println!("- Initial stream window: 8MB");
+
+    let (stream, _handle) = subscribe(config, request);
+    let mut stream = Box::pin(stream);
+
+    while let Some(update) = stream.next().await {
+        match update {
+            Ok(update) => {
+                println!("Received update: {:?}", update);
+            }
+            Err(e) => {
+                eprintln!("Stream error: {:?}", e);
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/rust/examples/stream_write_example.rs
+++ b/rust/examples/stream_write_example.rs
@@ -1,0 +1,140 @@
+use helius_laserstream::{subscribe, LaserstreamConfig, SubscribeRequest, SubscribeRequestFilterSlots};
+use futures::StreamExt;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use tokio::time::{sleep, Duration};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let endpoint = std::env::var("LASERSTREAM_PRODUCTION_ENDPOINT")
+        .unwrap_or_else(|_| "".to_string());
+    let api_key = std::env::var("LASERSTREAM_PRODUCTION_API_KEY")
+        .expect("LASERSTREAM_PRODUCTION_API_KEY environment variable must be set");
+
+    let config = LaserstreamConfig::new(endpoint, api_key)
+        .with_max_reconnect_attempts(5);
+
+    // Initial subscription request - just subscribe to slots
+    let mut slots_filter = HashMap::new();
+    slots_filter.insert(
+        "client".to_string(),
+        SubscribeRequestFilterSlots {
+            filter_by_commitment: Some(true),
+            ..Default::default()
+        },
+    );
+
+    let initial_request = SubscribeRequest {
+        slots: slots_filter,
+        commitment: Some(1), // Confirmed
+        ..Default::default()
+    };
+
+    println!("🚀 Laserstream Bidirectional Stream Example");
+    println!("📡 Starting initial subscription to slots...");
+
+    let (stream, handle) = subscribe(config, initial_request);
+    let mut stream = Box::pin(stream);
+
+    let message_count = Arc::new(AtomicU32::new(0));
+    let handle_clone = handle.clone();
+    let count_clone = message_count.clone();
+
+    // Spawn a task to add subscriptions dynamically
+    tokio::spawn(async move {
+        // Wait for 5 slot updates before adding transaction subscription
+        while count_clone.load(Ordering::Relaxed) < 5 {
+            sleep(Duration::from_millis(100)).await;
+        }
+
+        println!("\n📝 Adding transaction subscription after 5 slots...");
+        
+        let mut transactions_filter = HashMap::new();
+        transactions_filter.insert(
+            "client".to_string(),
+            helius_laserstream::SubscribeRequestFilterTransactions {
+                vote: Some(false),
+                failed: Some(false),
+                ..Default::default()
+            },
+        );
+
+        let transaction_request = SubscribeRequest {
+            transactions: transactions_filter,
+            ..Default::default()
+        };
+
+        if let Err(e) = handle_clone.write(transaction_request).await {
+            eprintln!("❌ Failed to add transaction subscription: {}", e);
+        } else {
+            println!("✅ Successfully added transaction subscription");
+        }
+
+        // Wait for more messages before adding block subscription
+        while count_clone.load(Ordering::Relaxed) < 15 {
+            sleep(Duration::from_millis(100)).await;
+        }
+
+        println!("\n📦 Adding block subscription...");
+        
+        let mut blocks_filter = HashMap::new();
+        blocks_filter.insert(
+            "client".to_string(),
+            helius_laserstream::SubscribeRequestFilterBlocks {
+                include_transactions: Some(true),
+                include_accounts: Some(false),
+                include_entries: Some(false),
+                ..Default::default()
+            },
+        );
+
+        let block_request = SubscribeRequest {
+            blocks: blocks_filter,
+            ..Default::default()
+        };
+
+        if let Err(e) = handle_clone.write(block_request).await {
+            eprintln!("❌ Failed to add block subscription: {}", e);
+        } else {
+            println!("✅ Successfully added block subscription");
+        }
+    });
+
+    // Process the stream
+    while let Some(update) = stream.next().await {
+        match update {
+            Ok(update) => {
+                let count = message_count.fetch_add(1, Ordering::Relaxed) + 1;
+
+                match &update.update_oneof {
+                    Some(helius_laserstream::grpc::subscribe_update::UpdateOneof::Slot(slot)) => {
+                        println!("🎰 Slot update #{}: {}", count, slot.slot);
+                    }
+                    Some(helius_laserstream::grpc::subscribe_update::UpdateOneof::Transaction(tx)) => {
+                        println!("💸 Transaction update: {} bytes", tx.transaction.as_ref().map_or(0, |t| t.data.len()));
+                    }
+                    Some(helius_laserstream::grpc::subscribe_update::UpdateOneof::Block(block)) => {
+                        println!("📦 Block update: slot {}, {} transactions", 
+                            block.slot,
+                            block.transactions.as_ref().map_or(0, |txs| txs.len())
+                        );
+                    }
+                    _ => {}
+                }
+
+                // Stop after 25 messages
+                if count >= 25 {
+                    println!("\n🛑 Received 25 messages, shutting down...");
+                    break;
+                }
+            }
+            Err(e) => {
+                eprintln!("❌ Stream error: {}", e);
+                // The stream will automatically reconnect
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -7,6 +7,58 @@ pub struct LaserstreamConfig {
     /// Maximum number of reconnection attempts. Defaults to 10.
     /// A hard cap of 240 attempts (20 minutes / 5 seconds) is enforced internally.
     pub max_reconnect_attempts: Option<u32>,
+    /// gRPC channel options
+    pub channel_options: ChannelOptions,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChannelOptions {
+    /// Connect timeout in seconds. Default: 10
+    pub connect_timeout_secs: Option<u64>,
+    /// Request timeout in seconds. Default: 30
+    pub timeout_secs: Option<u64>,
+    /// Max message size for receiving in bytes. Default: 1GB
+    pub max_decoding_message_size: Option<usize>,
+    /// Max message size for sending in bytes. Default: 32MB
+    pub max_encoding_message_size: Option<usize>,
+    /// HTTP/2 keep-alive interval in seconds. Default: 30
+    pub http2_keep_alive_interval_secs: Option<u64>,
+    /// Keep-alive timeout in seconds. Default: 5
+    pub keep_alive_timeout_secs: Option<u64>,
+    /// Enable keep-alive while idle. Default: true
+    pub keep_alive_while_idle: Option<bool>,
+    /// Initial stream window size in bytes. Default: 4MB
+    pub initial_stream_window_size: Option<u32>,
+    /// Initial connection window size in bytes. Default: 8MB
+    pub initial_connection_window_size: Option<u32>,
+    /// Enable HTTP/2 adaptive window. Default: true
+    pub http2_adaptive_window: Option<bool>,
+    /// Enable TCP no-delay. Default: true
+    pub tcp_nodelay: Option<bool>,
+    /// TCP keep-alive interval in seconds. Default: 60
+    pub tcp_keepalive_secs: Option<u64>,
+    /// Buffer size in bytes. Default: 64KB
+    pub buffer_size: Option<usize>,
+}
+
+impl Default for ChannelOptions {
+    fn default() -> Self {
+        Self {
+            connect_timeout_secs: None,
+            timeout_secs: None,
+            max_decoding_message_size: None,
+            max_encoding_message_size: None,
+            http2_keep_alive_interval_secs: None,
+            keep_alive_timeout_secs: None,
+            keep_alive_while_idle: None,
+            initial_stream_window_size: None,
+            initial_connection_window_size: None,
+            http2_adaptive_window: None,
+            tcp_nodelay: None,
+            tcp_keepalive_secs: None,
+            buffer_size: None,
+        }
+    }
 }
 
 impl Default for LaserstreamConfig {
@@ -15,6 +67,7 @@ impl Default for LaserstreamConfig {
             api_key: String::new(),
             endpoint: String::new(),
             max_reconnect_attempts: None, // Default to None
+            channel_options: ChannelOptions::default(),
         }
     }
 }
@@ -25,12 +78,19 @@ impl LaserstreamConfig {
             endpoint,
             api_key,
             max_reconnect_attempts: None, // Default to None
+            channel_options: ChannelOptions::default(),
         }
     }
 
     /// Sets the maximum number of reconnection attempts.
     pub fn with_max_reconnect_attempts(mut self, attempts: u32) -> Self {
         self.max_reconnect_attempts = Some(attempts);
+        self
+    }
+
+    /// Sets custom channel options.
+    pub fn with_channel_options(mut self, options: ChannelOptions) -> Self {
+        self.channel_options = options;
         self
     }
 }

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -35,4 +35,7 @@ pub enum LaserstreamError {
 
     #[error("Invalid API Key format")]
     InvalidApiKeyFormat,
+    
+    #[error("Connection error: {0}")]
+    ConnectionError(String),
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -9,8 +9,8 @@ pub mod client;
 pub mod config;
 pub mod error;
 
-pub use client::subscribe;
-pub use config::LaserstreamConfig;
+pub use client::{subscribe, StreamHandle};
+pub use config::{LaserstreamConfig, ChannelOptions};
 pub use error::LaserstreamError;
 
 // Re-export necessary types from yellowstone-grpc-proto
@@ -18,7 +18,7 @@ pub use yellowstone_grpc_proto::geyser::{
     subscribe_request_filter_accounts_filter::Filter as AccountsFilterOneof,
     subscribe_request_filter_accounts_filter_lamports::Cmp as AccountsFilterLamports,
     subscribe_request_filter_accounts_filter_memcmp::Data as AccountsFilterMemcmpOneof,
-    SubscribeRequestAccountsDataSlice, SubscribeRequestFilterAccounts,
+    SubscribeRequest, SubscribeRequestAccountsDataSlice, SubscribeRequestFilterAccounts,
     SubscribeRequestFilterAccountsFilter, SubscribeRequestFilterAccountsFilterLamports,
     SubscribeRequestFilterAccountsFilterMemcmp, SubscribeRequestFilterBlocks,
     SubscribeRequestFilterBlocksMeta, SubscribeRequestFilterEntry, SubscribeRequestFilterSlots,

--- a/rust/test/account_integrity.rs
+++ b/rust/test/account_integrity.rs
@@ -84,7 +84,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let latest_ls = Arc::clone(&latest_ls);
         let max_ls_ptr = Arc::clone(&max_slot_ls);
         let handle = tokio::spawn(async move {
-            let stream = subscribe(laser_cfg, req);
+            let (stream, _handle) = subscribe(laser_cfg, req);
             futures::pin_mut!(stream);
             while let Some(res) = stream.next().await {
                 match res {

--- a/rust/test/block_integrity.rs
+++ b/rust/test/block_integrity.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Starting block integrity test. Subscribing to slots…");
 
     let api_key_clone = cfg.api_key.clone();
-    let mut stream = subscribe(cfg, req);
+    let (stream, _handle) = subscribe(cfg, req);
     futures::pin_mut!(stream);
 
     while let Some(res) = stream.next().await {

--- a/rust/test/transaction_integrity.rs
+++ b/rust/test/transaction_integrity.rs
@@ -73,7 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let status_map = Arc::clone(&status_map);
         let err_ls_counter = Arc::clone(&err_ls);
         tokio::spawn(async move {
-            let mut stream = subscribe(laser_cfg, req);
+            let (stream, _handle) = subscribe(laser_cfg, req);
             futures::pin_mut!(stream);
             while let Some(res) = stream.next().await {
                 match res {


### PR DESCRIPTION
## This PR adds two core features to all 3 Laserstream SDKs:

### Channel Options
- Configurable gRPC connection parameters same as grpc js

### Bidirectional Streaming
- Add/modify subscriptions without reconnecting

### Breaking Changes
- Rust subscribe() function now returns a tuple (Stream, StreamHandle) instead of just Stream before