### PR TITLE
Adding flag to enable/display replay in all 3 clients

### DIFF
--- a/go/examples/block-sub.go
+++ b/go/examples/block-sub.go
@@ -42,7 +42,9 @@ func main() {
 	client := laserstream.NewClient(clientConfig)
 
 	dataCallback := func(data *laserstream.SubscribeUpdate) {
-		log.Printf("Block Update: %+v", data)
+		if blockUpdate := data.GetBlock(); blockUpdate != nil {
+			log.Printf("Block: %d", blockUpdate.Slot)
+		}
 	}
 
 	errorCallback := func(err error) {

--- a/javascript/Cargo.lock
+++ b/javascript/Cargo.lock
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "laserstream-napi"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "base64 0.21.7",
  "bs58",

--- a/javascript/Cargo.toml
+++ b/javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laserstream-napi"
-version = "0.1.0"
+version = "0.1.5"
 edition = "2021"
 
 [lib]

--- a/javascript/client.d.ts
+++ b/javascript/client.d.ts
@@ -50,6 +50,8 @@ export interface LaserstreamConfig {
   endpoint: string;
   maxReconnectAttempts?: number;
   channelOptions?: ChannelOptions;
+  // When true, enable replay on reconnects (uses fromSlot and internal slot tracking). When false, no replay.
+  replay?: boolean;
 }
 
 // Subscription request interface
@@ -67,8 +69,6 @@ export interface SubscribeRequest {
   fromSlot?: number;
 }
 
-// Re-export SubscribeUpdate from proto-types
-// (already exported via export * from './proto-types')
 
 // Stream handle interface
 export interface StreamHandle {

--- a/javascript/client.js
+++ b/javascript/client.js
@@ -25,7 +25,13 @@ async function subscribe(config, request, onData, onError) {
   await ensureProtobufInitialized();
 
   // Create NAPI client instance directly
-  const napiClient = new NapiClient(config.endpoint, config.apiKey, config.maxReconnectAttempts, config.channelOptions);
+  const napiClient = new NapiClient(
+    config.endpoint,
+    config.apiKey,
+    config.maxReconnectAttempts,
+    config.channelOptions,
+    config.replay
+  );
 
   // Wrap the callbacks to decode protobuf bytes
   const wrappedCallback = (error, updateBytes) => {

--- a/javascript/examples/block-sub.ts
+++ b/javascript/examples/block-sub.ts
@@ -1,40 +1,26 @@
-import { 
-  subscribe, 
-  CommitmentLevel, 
-  SubscribeUpdate,
-  SubscribeUpdateBlock,
-  SubscribeUpdateAccountInfo,
-  SubscribeUpdateTransactionInfo,
-  LaserstreamConfig, 
-  CompressionAlgorithms 
-} from '../client';
-import * as bs58 from 'bs58';
-const credentials = require('../test-config');
+import { subscribe, CommitmentLevel, LaserstreamConfig, CompressionAlgorithms } from '../client';
+const cfg = require('../test-config');
 
-async function runBlockSubscription() {
-  console.log('🧱 Laserstream Block Subscription Example');
-  console.log('🔧 Testing compression with zstd...');
-
+async function main() {
   const config: LaserstreamConfig = {
-    apiKey: credentials.laserstreamProduction.apiKey,
-    endpoint: credentials.laserstreamProduction.endpoint,
+    apiKey: cfg.laserstreamProduction.apiKey,
+    endpoint: cfg.laserstreamProduction.endpoint,
     channelOptions: {
       'grpc.default_compression_algorithm': CompressionAlgorithms.gzip,  // Try gzip instead
       'grpc.default_compression_level': 'high',  // High compression level
     },
   };
 
-  // Subscribe to block updates
   const request = {
     blocks: {
-      "all-blocks": {
+      "client": {
         accountInclude: [],
-        includeTransactions: true,
-        includeAccounts: true,
-        includeEntries: true
+        includeTransactions: false,
+        includeAccounts: false,
+        includeEntries: false
       }
     },
-    commitment: CommitmentLevel.PROCESSED,
+    commitment: CommitmentLevel.CONFIRMED,
     accounts: {},
     slots: {},
     transactions: {},
@@ -44,105 +30,21 @@ async function runBlockSubscription() {
     accountsDataSlice: [],
   };
 
-  // Bandwidth measurement variables
-  let totalBytes = 0;
-  let messageCount = 0;
-  const startTime = Date.now();
-  let lastReportTime = startTime;
-  const reportIntervalMs = 5000; // Report every 5 seconds
-
-  // Helper to calculate message size
-  function calculateMessageSize(obj: any): number {
-    // Estimate size by stringifying the object
-    return JSON.stringify(obj).length;
-  }
-
-  const stream = await subscribe(
+  await subscribe(
     config,
     request,
-    async (update: SubscribeUpdate) => {
+    async (update) => {
       if (update.block) {
-        const blockUpdate: SubscribeUpdateBlock = update.block;
-        console.log('\n🧱 Block Update Received!');
-        console.log('  - Slot:', blockUpdate.slot);
-        console.log('  - Blockhash:', blockUpdate.blockhash);
-        console.log('  - Parent Slot:', blockUpdate.parentSlot);
-        console.log('  - Parent Blockhash:', blockUpdate.parentBlockhash);
-        console.log('  - Block Height:', blockUpdate.blockHeight?.blockHeight || 'N/A');
-        console.log('  - Block Time:', blockUpdate.blockTime?.timestamp || 'N/A');
-        console.log('  - Executed Transaction Count:', blockUpdate.executedTransactionCount);
-        console.log('  - Updated Account Count:', blockUpdate.updatedAccountCount);
-        console.log('  - Entries Count:', blockUpdate.entriesCount);
-        console.log('  - Rewards:', blockUpdate.rewards?.rewards?.length || 0);
-        
-        // Show transaction details
-        if (blockUpdate.transactions && blockUpdate.transactions.length > 0) {
-          console.log(`  - Transactions: ${blockUpdate.transactions.length}`);
-          const firstTx: SubscribeUpdateTransactionInfo = blockUpdate.transactions[0];
-          console.log('    First Transaction:');
-          console.log('      - Signature:', firstTx.signature ? bs58.encode(firstTx.signature) : 'N/A');
-          console.log('      - Is Vote:', firstTx.isVote);
-          console.log('      - Index:', firstTx.index);
-        }
-        
-        // Show account details
-        if (blockUpdate.accounts && blockUpdate.accounts.length > 0) {
-          console.log(`  - Accounts: ${blockUpdate.accounts.length}`);
-          const firstAccount: SubscribeUpdateAccountInfo = blockUpdate.accounts[0];
-          console.log('    First Account:');
-          console.log('      - Pubkey:', firstAccount.pubkey ? bs58.encode(firstAccount.pubkey) : 'N/A');
-          console.log('      - Lamports:', firstAccount.lamports);
-        }
-      }
-      
-      // Measure the message size
-      const messageSize = calculateMessageSize(update);
-      totalBytes += messageSize;
-      messageCount++;
-      
-      // Report bandwidth every 5 seconds
-      const now = Date.now();
-      if (now - lastReportTime >= reportIntervalMs) {
-        const elapsedSeconds = (now - startTime) / 1000;
-        const mbReceived = totalBytes / (1024 * 1024);
-        const mbPerSecond = mbReceived / elapsedSeconds;
-        
-        console.log(`\n📊 Bandwidth Report (with compression):`);
-        console.log(`   Total data received: ${mbReceived.toFixed(2)} MB`);
-        console.log(`   Messages received: ${messageCount}`);
-        console.log(`   Average message size: ${(totalBytes / messageCount / 1024).toFixed(2)} KB`);
-        console.log(`   Bandwidth: ${mbPerSecond.toFixed(2)} MB/s`);
-        console.log(`   Time elapsed: ${elapsedSeconds.toFixed(1)}s\n`);
-        
-        lastReportTime = now;
+        console.log(`Block: ${update.block.slot}`);
       }
     },
-    async (error: Error) => {
-      console.error('❌ Stream error:', error);
+    async (error) => {
+      console.error('Error:', error);
     }
   );
 
-  console.log(`✅ Block subscription started with ID: ${stream.id}`);
-  console.log(`📊 Measuring bandwidth with zstd compression enabled...`);
-
-  // Cleanup on exit
-  process.on('SIGINT', () => {
-    // Final report
-    const elapsedSeconds = (Date.now() - startTime) / 1000;
-    const mbReceived = totalBytes / (1024 * 1024);
-    const mbPerSecond = mbReceived / elapsedSeconds;
-    
-    console.log(`\n📊 Final Bandwidth Report (with zstd compression):`);
-    console.log(`   Total data received: ${mbReceived.toFixed(2)} MB`);
-    console.log(`   Messages received: ${messageCount}`);
-    console.log(`   Average message size: ${(totalBytes / messageCount / 1024).toFixed(2)} KB`);
-    console.log(`   Average bandwidth: ${mbPerSecond.toFixed(2)} MB/s`);
-    console.log(`   Total time: ${elapsedSeconds.toFixed(1)}s`);
-    
-    console.log('\n🛑 Cancelling stream...');
-    stream.cancel();
-    process.exit(0);
-  });
+  // Keep alive
+  await new Promise(() => {});
 }
 
-runBlockSubscription().catch(console.error); 
+main().catch(console.error); 

--- a/javascript/index.d.ts
+++ b/javascript/index.d.ts
@@ -11,7 +11,7 @@ export const enum CommitmentLevel {
   FINALIZED = 2
 }
 export declare class LaserstreamClient {
-  constructor(endpoint: string, token?: string | undefined | null, maxReconnectAttempts?: number | undefined | null, channelOptions?: object | undefined | null)
+  constructor(endpoint: string, token?: string | undefined | null, maxReconnectAttempts?: number | undefined | null, channelOptions?: object | undefined | null, replay?: boolean | undefined | null)
   subscribe(request: any, callback: (error: Error | null, updateBytes: Uint8Array) => void): Promise<StreamHandle>
 }
 export declare class StreamHandle {

--- a/javascript/napi-src/client.rs
+++ b/javascript/napi-src/client.rs
@@ -25,6 +25,9 @@ pub struct ClientInner {
     token: Option<String>,
     max_reconnect_attempts: u32,
     channel_options: Option<ChannelOptions>,
+    // When true, enable replay behavior (internal slot tracking + from_slot on reconnects)
+    // When false, disable replay (no internal slot tracking and no from_slot on reconnects)
+    replay: bool,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -169,12 +172,15 @@ impl ClientInner {
         token: Option<String>,
         max_reconnect_attempts: Option<u32>,
         channel_options: Option<ChannelOptions>,
+        replay: Option<bool>,
     ) -> Result<Self> {
         Ok(Self {
             endpoint,
             token,
             max_reconnect_attempts: max_reconnect_attempts.unwrap_or(120),
             channel_options,
+            // Default to true (replay enabled) unless explicitly set to false
+            replay: replay.unwrap_or(true),
         })
     }
 
@@ -438,6 +444,7 @@ impl ClientInner {
             ts_callback,
             self.max_reconnect_attempts,
             self.channel_options.clone(),
+            self.replay,
         )?);
 
         // Register stream in global registry for lifecycle management

--- a/javascript/napi-src/lib.rs
+++ b/javascript/napi-src/lib.rs
@@ -115,6 +115,7 @@ impl LaserstreamClient {
         token: Option<String>,
         max_reconnect_attempts: Option<u32>,
         channel_options: Option<Object>,
+        replay: Option<bool>,
     ) -> Result<Self> {
         let parsed_channel_options = if let Some(opts_obj) = channel_options {
             let opts: client::ChannelOptions = env.from_js_value(opts_obj)?;
@@ -128,6 +129,7 @@ impl LaserstreamClient {
             token,
             max_reconnect_attempts,
             parsed_channel_options,
+            replay,
         )?);
         Ok(Self { inner })
     }
@@ -183,6 +185,7 @@ impl StreamHandle {
         // Parse the JavaScript request object into a protobuf SubscribeRequest
         let client_inner = client::ClientInner::new(
             String::new(), // dummy values, we only need the parsing functionality
+            None,
             None,
             None,
             None,

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helius-laserstream",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "High-performance Laserstream gRPC client with automatic reconnection",
   "main": "client.js",
   "types": "client.d.ts",
@@ -79,9 +79,9 @@
     }
   },
   "optionalDependencies": {
-    "helius-laserstream-darwin-arm64": "0.1.4",
-    "helius-laserstream-darwin-x64": "0.1.4",
-    "helius-laserstream-linux-x64-gnu": "0.1.4"
+    "helius-laserstream-darwin-arm64": "0.1.5",
+    "helius-laserstream-darwin-x64": "0.1.5",
+    "helius-laserstream-linux-x64-gnu": "0.1.5"
   },
   "dependencies": {
     "@types/protobufjs": "^6.0.0",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1047,7 +1047,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "helius-laserstream"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "async-stream",
  "bs58",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helius-laserstream"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2021"
 authors = ["Helius <support@helius.xyz>"]
 description = "Rust client for Helius LaserStream gRPC with robust reconnection and slot tracking"

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -21,6 +21,10 @@ pub struct LaserstreamConfig {
     pub max_reconnect_attempts: Option<u32>,
     /// gRPC channel options
     pub channel_options: ChannelOptions,
+    /// When true, enable replay on reconnects (uses from_slot and internal slot tracking).
+    /// When false, no replay - start from current slot on reconnects.
+    /// Default: true
+    pub replay: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -102,6 +106,7 @@ impl Default for LaserstreamConfig {
             endpoint: String::new(),
             max_reconnect_attempts: None, // Default to None
             channel_options: ChannelOptions::default(),
+            replay: true, // Default to true
         }
     }
 }
@@ -113,6 +118,7 @@ impl LaserstreamConfig {
             api_key,
             max_reconnect_attempts: None, // Default to None
             channel_options: ChannelOptions::default(),
+            replay: true, // Default to true
         }
     }
 
@@ -125,6 +131,14 @@ impl LaserstreamConfig {
     /// Sets custom channel options.
     pub fn with_channel_options(mut self, options: ChannelOptions) -> Self {
         self.channel_options = options;
+        self
+    }
+
+    /// Sets replay behavior on reconnects.
+    /// When true (default), uses from_slot and internal slot tracking for replay.
+    /// When false, starts from current slot on reconnects (no replay).
+    pub fn with_replay(mut self, replay: bool) -> Self {
+        self.replay = replay;
         self
     }
 }


### PR DESCRIPTION
## Add `replay` flag to control reconnection behavior across all clients

- Only adds internal slot subscription when replay enabled
- skips `from_slot` both from the original request and reconnects when replay is false