### PR TITLE
Go client: Adding context sub, cleaning up pongs and changing replay type

### DIFF
--- a/go/examples/accounts-data-slice-sub.go
+++ b/go/examples/accounts-data-slice-sub.go
@@ -28,7 +28,6 @@ func main() {
 	clientConfig := laserstream.LaserstreamConfig{
 		Endpoint: endpoint,
 		APIKey:   apiKey,
-		
 	}
 
 	commitmentLevel := laserstream.CommitmentLevel_PROCESSED

--- a/go/examples/block-meta-sub.go
+++ b/go/examples/block-meta-sub.go
@@ -28,7 +28,6 @@ func main() {
 	clientConfig := laserstream.LaserstreamConfig{
 		Endpoint: endpoint,
 		APIKey:   apiKey,
-		
 	}
 
 	commitmentLevel := laserstream.CommitmentLevel_PROCESSED

--- a/go/examples/block-sub.go
+++ b/go/examples/block-sub.go
@@ -28,7 +28,6 @@ func main() {
 	clientConfig := laserstream.LaserstreamConfig{
 		Endpoint: endpoint,
 		APIKey:   apiKey,
-		
 	}
 
 	commitmentLevel := laserstream.CommitmentLevel_PROCESSED

--- a/go/examples/context-sub.go
+++ b/go/examples/context-sub.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"os"
 	"os/signal"
@@ -16,18 +17,21 @@ func main() {
 
 	godotenv.Load("../.env")
 
-	endpoint := os.Getenv("LASERSTREAM_PRODUCTION_ENDPOINT")
+	endpoint := os.Getenv("LASERSTREAM_ENDPOINT")
 	if endpoint == "" {
 		log.Fatal("LASERSTREAM_PRODUCTION_ENDPOINT required")
 	}
-	apiKey := os.Getenv("LASERSTREAM_PRODUCTION_API_KEY")
+	apiKey := os.Getenv("LASERSTREAM_API_KEY")
 	if apiKey == "" {
 		log.Fatal("LASERSTREAM_PRODUCTION_API_KEY required")
 	}
 
+	// replay := false
+
 	clientConfig := laserstream.LaserstreamConfig{
 		Endpoint: endpoint,
 		APIKey:   apiKey,
+		// Replay:   &replay,
 	}
 
 	commitmentLevel := laserstream.CommitmentLevel_PROCESSED
@@ -44,21 +48,27 @@ func main() {
 	client := laserstream.NewClient(clientConfig)
 
 	dataCallback := func(data *laserstream.SubscribeUpdate) {
-		log.Printf("Slot Update: %+v", data)
+		if slotUpdate, ok := data.UpdateOneof.(*laserstream.SubscribeUpdate_Slot); ok {
+			if slotUpdate.Slot != nil {
+				log.Printf("Slot: %d", slotUpdate.Slot.Slot)
+				return
+			}
+		}
+		log.Printf("Update: %+v", data)
 	}
 
 	errorCallback := func(err error) {
 		log.Printf("Error: %v", err)
 	}
 
-	err := client.Subscribe(subscriptionRequest, dataCallback, errorCallback)
-	if err != nil {
+	// Use a context that cancels on SIGINT/SIGTERM
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if err := client.SubscribeWithContext(ctx, subscriptionRequest, dataCallback, errorCallback); err != nil {
 		log.Fatalf("Failed to subscribe: %v", err)
 	}
 
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	<-sigChan
-
-	client.Unsubscribe()
+	// Block until context cancellation (Ctrl+C or SIGTERM)
+	<-ctx.Done()
 }

--- a/go/examples/entry-sub.go
+++ b/go/examples/entry-sub.go
@@ -28,7 +28,6 @@ func main() {
 	clientConfig := laserstream.LaserstreamConfig{
 		Endpoint: endpoint,
 		APIKey:   apiKey,
-		
 	}
 
 	commitmentLevel := laserstream.CommitmentLevel_PROCESSED

--- a/go/examples/transaction-status-sub.go
+++ b/go/examples/transaction-status-sub.go
@@ -28,7 +28,6 @@ func main() {
 	clientConfig := laserstream.LaserstreamConfig{
 		Endpoint: endpoint,
 		APIKey:   apiKey,
-		
 	}
 
 	commitmentLevel := laserstream.CommitmentLevel_PROCESSED

--- a/go/examples/transaction-sub.go
+++ b/go/examples/transaction-sub.go
@@ -28,7 +28,6 @@ func main() {
 	clientConfig := laserstream.LaserstreamConfig{
 		Endpoint: endpoint,
 		APIKey:   apiKey,
-		
 	}
 
 	commitmentLevel := laserstream.CommitmentLevel_PROCESSED

--- a/go/test/internal-slot-filter-test.go
+++ b/go/test/internal-slot-filter-test.go
@@ -86,7 +86,6 @@ func main() {
 	config := laserstream.LaserstreamConfig{
 		Endpoint: endpoint,
 		APIKey:   apiKey,
-		
 	}
 
 	userSlotFilterID := "user-slot-test"


### PR DESCRIPTION
- Context: Added SubscribeWithContext(ctx, ...) and made Subscribe delegate. Lets callers control lifecycle with deadlines/cancellation and propagate metadata/tracing via ctx. Previously Background() prevented tying the stream to a request or deterministic shutdown. Now ctx.Done() cleanly stops dial/stream/loop and prevents further callbacks.

- Replay: Switched Replay to *bool (nil => true) so struct literals default to replay; constructor sets true.

- Pongs: Suppressed server pong updates from reaching user callbacks.