### PR TITLE
Fix protobuf defaults to match Yellowstone gRPC format

### DIFF
--- a/javascript/Cargo.lock
+++ b/javascript/Cargo.lock
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "laserstream-napi"
-version = "0.1.5"
+version = "0.1.7"
 dependencies = [
  "base64 0.21.7",
  "bs58",

--- a/javascript/Cargo.toml
+++ b/javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laserstream-napi"
-version = "0.1.5"
+version = "0.1.7"
 edition = "2021"
 
 [lib]

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helius-laserstream",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "High-performance Laserstream gRPC client with automatic reconnection",
   "main": "client.js",
   "types": "client.d.ts",
@@ -82,12 +82,12 @@
     }
   },
   "optionalDependencies": {
-    "helius-laserstream-darwin-arm64": "0.1.6",
-    "helius-laserstream-darwin-x64": "0.1.6",
-    "helius-laserstream-linux-x64-gnu": "0.1.6",
-    "helius-laserstream-linux-arm64-gnu": "0.1.6",
-    "helius-laserstream-linux-x64-musl": "0.1.6",
-    "helius-laserstream-linux-arm64-musl": "0.1.6"
+    "helius-laserstream-darwin-arm64": "0.1.7",
+    "helius-laserstream-darwin-x64": "0.1.7",
+    "helius-laserstream-linux-arm64-gnu": "0.1.7",
+    "helius-laserstream-linux-arm64-musl": "0.1.7",
+    "helius-laserstream-linux-x64-gnu": "0.1.7",
+    "helius-laserstream-linux-x64-musl": "0.1.7"
   },
   "dependencies": {
     "@types/protobufjs": "^6.0.0",
@@ -96,13 +96,13 @@
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4",
     "@solana/web3.js": "^1.98.2",
-    "@triton-one/yellowstone-grpc": "^4.0.2",
     "@types/bs58": "^5.0.0",
     "@types/node": "^20.0.0",
     "@types/node-fetch": "^2.6.12",
     "bs58": "^5.0.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "yellowstone-grpc-types-extension": "1.0.0"
   },
   "jest": {
     "preset": "ts-jest",

--- a/javascript/proto-decoder.js
+++ b/javascript/proto-decoder.js
@@ -38,7 +38,7 @@ function decodeSubscribeUpdate(bytes) {
       longs: String,           // Convert uint64 to string (like Yellowstone)
       enums: Number,           // Keep enums as numbers
       bytes: Buffer,           // Keep bytes as Buffer (exactly like Yellowstone)
-      defaults: false,         // Don't include default values
+      defaults: true,         // Include default values
       arrays: true,            // Always include arrays
       objects: true,           // Always include objects
       oneofs: false             // Do not include oneof virtual fields


### PR DESCRIPTION
Laserstream's protobuf decoder was omitting fields with default values (0, false, empty), causing JSON structure mismatches with Yellowstone gRPC.