### PR TITLE
feat: add support for http endpoints

### DIFF
--- a/javascript/Cargo.lock
+++ b/javascript/Cargo.lock
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "laserstream-napi"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.21.7",
  "bs58",

--- a/javascript/Cargo.toml
+++ b/javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laserstream-napi"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [lib]

--- a/javascript/napi-src/stream.rs
+++ b/javascript/napi-src/stream.rs
@@ -292,9 +292,13 @@ impl StreamInner {
                 .max_decoding_message_size(1_000_000_000)
                 .timeout(Duration::from_secs(10));
         }
-        
-        builder = builder.tls_config(ClientTlsConfig::new().with_enabled_roots())?;
-        
+
+        let use_tls = !endpoint.to_lowercase().starts_with("http://");
+
+        if use_tls {
+            builder = builder.tls_config(ClientTlsConfig::new().with_enabled_roots())?;
+        }
+
         if let Some(ref token) = token {
             builder = builder.x_token(Some(token.clone()))?;
         }

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "helius-laserstream",
-  "version": "0.1.9",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "helius-laserstream",
-      "version": "0.1.9",
+      "version": "0.2.1",
       "cpu": [
         "x64",
         "arm64"
@@ -34,12 +34,12 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "helius-laserstream-darwin-arm64": "0.1.9",
-        "helius-laserstream-darwin-x64": "0.1.9",
-        "helius-laserstream-linux-arm64-gnu": "0.1.9",
-        "helius-laserstream-linux-arm64-musl": "0.1.9",
-        "helius-laserstream-linux-x64-gnu": "0.1.9",
-        "helius-laserstream-linux-x64-musl": "0.1.9"
+        "helius-laserstream-darwin-arm64": "0.2.1",
+        "helius-laserstream-darwin-x64": "0.2.1",
+        "helius-laserstream-linux-arm64-gnu": "0.2.1",
+        "helius-laserstream-linux-arm64-musl": "0.2.1",
+        "helius-laserstream-linux-x64-gnu": "0.2.1",
+        "helius-laserstream-linux-x64-musl": "0.2.1"
       }
     },
     "node_modules/@babel/runtime": {

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helius-laserstream",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "High-performance Laserstream gRPC client with automatic reconnection",
   "main": "client.js",
   "types": "client.d.ts",
@@ -83,12 +83,12 @@
     }
   },
   "optionalDependencies": {
-    "helius-laserstream-darwin-arm64": "0.2.0",
-    "helius-laserstream-darwin-x64": "0.2.0",
-    "helius-laserstream-linux-arm64-gnu": "0.2.0",
-    "helius-laserstream-linux-arm64-musl": "0.2.0",
-    "helius-laserstream-linux-x64-gnu": "0.2.0",
-    "helius-laserstream-linux-x64-musl": "0.2.0"
+    "helius-laserstream-darwin-arm64": "0.2.1",
+    "helius-laserstream-darwin-x64": "0.2.1",
+    "helius-laserstream-linux-arm64-gnu": "0.2.1",
+    "helius-laserstream-linux-arm64-musl": "0.2.1",
+    "helius-laserstream-linux-x64-gnu": "0.2.1",
+    "helius-laserstream-linux-x64-musl": "0.2.1"
   },
   "dependencies": {
     "@types/protobufjs": "^6.0.0",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1365,7 +1365,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helius-laserstream"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-stream",
  "bs58",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helius-laserstream"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Helius <support@helius.xyz>"]
 description = "Rust client for Helius LaserStream gRPC with robust reconnection and slot tracking"

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -239,7 +239,9 @@ async fn connect_and_subscribe_once(
     tonic::Status,
 > {
     let options = &config.channel_options;
-    
+
+    let use_tls = !config.endpoint.to_lowercase().starts_with("http://");
+
     let mut builder = GeyserGrpcClient::build_from_shared(config.endpoint.clone())
         .map_err(|e| tonic::Status::internal(format!("Failed to build client: {}", e)))?
         .x_token(Some(api_key))
@@ -251,15 +253,23 @@ async fn connect_and_subscribe_once(
         .http2_keep_alive_interval(Duration::from_secs(options.http2_keep_alive_interval_secs.unwrap_or(30)))
         .keep_alive_timeout(Duration::from_secs(options.keep_alive_timeout_secs.unwrap_or(5)))  
         .keep_alive_while_idle(options.keep_alive_while_idle.unwrap_or(true))
-        .initial_stream_window_size(options.initial_stream_window_size.or(Some(1024 * 1024 * 4)))      // 4MB default
-        .initial_connection_window_size(options.initial_connection_window_size.or(Some(1024 * 1024 * 8)))  // 8MB default
-        .http2_adaptive_window(options.http2_adaptive_window.unwrap_or(true))                             // Dynamic window sizing
-        .tcp_nodelay(options.tcp_nodelay.unwrap_or(true))                                       // Disable Nagle's algorithm
-        .tcp_keepalive(options.tcp_keepalive_secs.map(Duration::from_secs))           // TCP keepalive
-        .buffer_size(options.buffer_size.or(Some(1024 * 64)))                           // 64KB default
-        .tls_config(ClientTlsConfig::new().with_enabled_roots())
-        .map_err(|e| tonic::Status::internal(format!("TLS config error: {}", e)))?;
-    
+        .initial_stream_window_size(options.initial_stream_window_size.or(Some(1024 * 1024 * 4))) // 4MB default
+        .initial_connection_window_size(
+            options
+                .initial_connection_window_size
+                .or(Some(1024 * 1024 * 8)),
+        ) // 8MB default
+        .http2_adaptive_window(options.http2_adaptive_window.unwrap_or(true)) // Dynamic window sizing
+        .tcp_nodelay(options.tcp_nodelay.unwrap_or(true)) // Disable Nagle's algorithm
+        .tcp_keepalive(options.tcp_keepalive_secs.map(Duration::from_secs)) // TCP keepalive
+        .buffer_size(options.buffer_size.or(Some(1024 * 64))); // 64KB default
+
+    if use_tls {
+        builder = builder
+            .tls_config(ClientTlsConfig::new().with_enabled_roots())
+            .map_err(|e| tonic::Status::internal(format!("TLS config error: {}", e)))?;
+    }
+
     // Configure compression if specified
     if let Some(send_comp) = options.send_compression {
         let encoding = match send_comp {


### PR DESCRIPTION
## Overview

As LaserStream and Dedicated Nodes both use Yellowstone gRPC under the hood, I think it's good to also use laserstream-sdk for connecting to the dedicated node, which might use  the bypass HTTP URL (http://abc-dedicated-bypass.helius-rpc.com:4001)

## Changes made in this PR

- Add support for http endpoints across SDKs
- Pump the package version

> [!NOTE]  
>  I created some examples and tested them locally to make sure these changes work