### PR TITLE
Fix Go SDK stream dying after Write() during replay

### DIFF
--- a/go/laserstream.go
+++ b/go/laserstream.go
@@ -489,7 +489,6 @@ func (c *Client) handleStream(ctx context.Context, stream pb.Geyser_SubscribeCli
 	}
 }
 
-// updateRequestForReconnection updates the request with from_slot for reconnection
 // mergeSubscribeRequest replaces the subscription fields in originalRequest with
 // the write request, preserving the internal slot tracker and from_slot.
 // This ensures writes survive reconnection, matching JS/Rust SDK behavior.
@@ -528,14 +527,16 @@ func (c *Client) mergeSubscribeRequest(modification *SubscribeRequest) {
 		c.originalRequest.Slots[internalKey] = internalVal
 	}
 
-	// Update commitment if specified
+	// Update commitment if specified, and sync commitmentLevel used for reconnection
 	if modification.Commitment != nil {
 		c.originalRequest.Commitment = modification.Commitment
+		c.commitmentLevel = int32(*modification.Commitment)
 	}
 
 	// Note: FromSlot and Ping are not replaced — they are connection-specific
 }
 
+// updateRequestForReconnection updates the request with from_slot for reconnection
 func (c *Client) updateRequestForReconnection() {
 	// Only use from_slot when replay is enabled
 	if !c.isReplayEnabled() {

--- a/go/laserstream.go
+++ b/go/laserstream.go
@@ -369,10 +369,14 @@ func (c *Client) handleStream(ctx context.Context, stream pb.Geyser_SubscribeCli
 				return
 			case req := <-c.writeChan:
 				if req != nil {
+					// Merge into originalRequest so writes survive reconnection
+					c.mergeSubscribeRequest(req)
 					if err := stream.Send(req); err != nil {
-						if c.errorCallback != nil {
-							c.errorCallback(fmt.Errorf("failed to send write request: %w", err))
+						select {
+						case sendErrChan <- err:
+						default:
 						}
+						return
 					}
 				}
 			case req := <-sendChan:
@@ -486,6 +490,52 @@ func (c *Client) handleStream(ctx context.Context, stream pb.Geyser_SubscribeCli
 }
 
 // updateRequestForReconnection updates the request with from_slot for reconnection
+// mergeSubscribeRequest replaces the subscription fields in originalRequest with
+// the write request, preserving the internal slot tracker and from_slot.
+// This ensures writes survive reconnection, matching JS/Rust SDK behavior.
+func (c *Client) mergeSubscribeRequest(modification *SubscribeRequest) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Save internal slot tracker before replacing slots
+	var internalKey string
+	var internalVal *SubscribeRequestFilterSlots
+	if c.originalRequest.Slots != nil {
+		for k, v := range c.originalRequest.Slots {
+			if strings.HasPrefix(k, "__internal_slot_tracker_") {
+				internalKey = k
+				internalVal = v
+				break
+			}
+		}
+	}
+
+	// Replace all subscription fields
+	c.originalRequest.Accounts = modification.Accounts
+	c.originalRequest.Slots = modification.Slots
+	c.originalRequest.Transactions = modification.Transactions
+	c.originalRequest.TransactionsStatus = modification.TransactionsStatus
+	c.originalRequest.Blocks = modification.Blocks
+	c.originalRequest.BlocksMeta = modification.BlocksMeta
+	c.originalRequest.Entry = modification.Entry
+	c.originalRequest.AccountsDataSlice = modification.AccountsDataSlice
+
+	// Restore internal slot tracker
+	if internalKey != "" && internalVal != nil {
+		if c.originalRequest.Slots == nil {
+			c.originalRequest.Slots = make(map[string]*SubscribeRequestFilterSlots)
+		}
+		c.originalRequest.Slots[internalKey] = internalVal
+	}
+
+	// Update commitment if specified
+	if modification.Commitment != nil {
+		c.originalRequest.Commitment = modification.Commitment
+	}
+
+	// Note: FromSlot and Ping are not replaced — they are connection-specific
+}
+
 func (c *Client) updateRequestForReconnection() {
 	// Only use from_slot when replay is enabled
 	if !c.isReplayEnabled() {

--- a/go/laserstream.go
+++ b/go/laserstream.go
@@ -32,7 +32,7 @@ const (
 // SDK metadata constants
 const (
 	SDKName    = "laserstream-go"
-	SDKVersion = "0.1.1"
+	SDKVersion = "0.1.2"
 )
 
 // Commitment levels
@@ -349,11 +349,21 @@ func (c *Client) connectAndStream(ctx context.Context) error {
 
 // handleStream processes messages from the stream
 func (c *Client) handleStream(ctx context.Context, stream pb.Geyser_SubscribeClient) error {
-	// Start a goroutine to handle write requests
+	// All Send() calls go through a single goroutine to avoid concurrent
+	// stream.Send() which is not safe on gRPC bidirectional streams.
+	sendChan := make(chan *SubscribeRequest, 100)
+	sendErrChan := make(chan error, 1)
+
+	sendCtx, cancelSend := context.WithCancel(ctx)
+	defer cancelSend()
+
 	go func() {
+		pingTicker := time.NewTicker(30 * time.Second)
+		defer pingTicker.Stop()
+
 		for {
 			select {
-			case <-ctx.Done():
+			case <-sendCtx.Done():
 				return
 			case <-c.writeStopChan:
 				return
@@ -365,30 +375,27 @@ func (c *Client) handleStream(ctx context.Context, stream pb.Geyser_SubscribeCli
 						}
 					}
 				}
-			}
-		}
-	}()
-
-	// Start periodic ping goroutine
-	pingCtx, cancelPing := context.WithCancel(ctx)
-	defer cancelPing()
-	
-	go func() {
-		ticker := time.NewTicker(30 * time.Second)
-		defer ticker.Stop()
-		
-		for {
-			select {
-			case <-pingCtx.Done():
-				return
-			case <-ticker.C:
+			case req := <-sendChan:
+				if req != nil {
+					if err := stream.Send(req); err != nil {
+						select {
+						case sendErrChan <- err:
+						default:
+						}
+						return
+					}
+				}
+			case <-pingTicker.C:
 				pingReq := &SubscribeRequest{
 					Ping: &SubscribeRequestPing{
 						Id: int32(time.Now().UnixMilli()),
 					},
 				}
 				if err := stream.Send(pingReq); err != nil {
-					// If ping fails, let main stream handler deal with reconnection
+					select {
+					case sendErrChan <- err:
+					default:
+					}
 					return
 				}
 			}
@@ -399,6 +406,8 @@ func (c *Client) handleStream(ctx context.Context, stream pb.Geyser_SubscribeCli
 		select {
 		case <-ctx.Done():
 			return nil
+		case err := <-sendErrChan:
+			return fmt.Errorf("send error: %w", err)
 		default:
 		}
 
@@ -419,12 +428,13 @@ func (c *Client) handleStream(ctx context.Context, stream pb.Geyser_SubscribeCli
 		// Handle ping/pong for connection health
 		if pingUpdate, ok := resp.UpdateOneof.(*pb.SubscribeUpdate_Ping); ok {
 			if pingUpdate.Ping != nil {
-				// Respond with pong
 				pongReq := &SubscribeRequest{
 					Ping: &SubscribeRequestPing{Id: 1},
 				}
-				if err := stream.Send(pongReq); err != nil {
-					return fmt.Errorf("failed to send pong: %w", err)
+				select {
+				case sendChan <- pongReq:
+				default:
+					return fmt.Errorf("failed to send pong: send channel full")
 				}
 			}
 			continue


### PR DESCRIPTION
## Summary
- Go SDK had 3 goroutines calling `stream.Send()` concurrently (write handler, ping ticker, pong responses). gRPC bidirectional streams are not safe for concurrent `Send()` — this corrupted the stream, causing `Recv()` to hang silently after replay completed.
- Serializes all `Send()` calls through a single goroutine via channels, matching JS/Rust SDK behavior (which naturally serialize sends via `tokio::select!{}`)
- Bumps Go SDK to v0.1.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)