### PR TITLE
Fix Rust and JS SDK write() dropping internal slot tracker

### DIFF
--- a/javascript/Cargo.lock
+++ b/javascript/Cargo.lock
@@ -1299,7 +1299,7 @@ dependencies = [
 
 [[package]]
 name = "laserstream-napi"
-version = "0.2.9"
+version = "0.3.1"
 dependencies = [
  "base64 0.21.7",
  "bs58",

--- a/javascript/napi-src/stream.rs
+++ b/javascript/napi-src/stream.rs
@@ -23,7 +23,7 @@ const FORK_DEPTH_SAFETY_MARGIN: u64 = 31; // Max fork depth for processed commit
 
 // SDK metadata constants
 const SDK_NAME: &str = "laserstream-javascript";
-const SDK_VERSION: &str = "0.3.1";
+const SDK_VERSION: &str = "0.3.2";
 
 /// Custom interceptor that adds SDK metadata headers to all gRPC requests
 #[derive(Clone)]
@@ -580,14 +580,21 @@ impl StreamInner {
 
                 // Handle write requests from the JavaScript client
                 Some(write_request) = write_rx.recv() => {
-                    // IMPORTANT: Merge the write_request into current_request so it persists across reconnections
-                    {
+                    // Merge the write_request into current_request so it persists across reconnections.
+                    // Then send the merged current_request (which preserves the internal slot
+                    // tracker) instead of the raw write_request. Yellowstone gRPC replaces
+                    // all subscriptions on each write, so the raw request would drop the
+                    // internal slot tracker and cause tracked_slot to go stale.
+                    let send_req = {
                         let mut req = current_request.lock();
                         Self::merge_subscribe_requests(&mut req, &write_request);
-                    }
+                        let mut snapshot = req.clone();
+                        snapshot.from_slot = None;
+                        snapshot.ping = None;
+                        snapshot
+                    };
 
-                    // Send the modification to the active stream
-                    if let Err(e) = sender.send(write_request).await {
+                    if let Err(e) = sender.send(send_req).await {
                         return Err(Box::new(e));
                     }
                 },

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helius-laserstream",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "High-performance Laserstream gRPC client with automatic reconnection",
   "main": "client.js",
   "types": "client.d.ts",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -990,7 +990,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helius-laserstream"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "async-stream",
  "bs58",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helius-laserstream"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 authors = ["Helius <support@helius.xyz>"]
 description = "Rust client for Helius LaserStream gRPC with robust reconnection and slot tracking"

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -22,7 +22,7 @@ use laserstream_core_proto::geyser::{
 const HARD_CAP_RECONNECT_ATTEMPTS: u32 = (20 * 60) / 5; // 20 mins / 5 sec interval
 const FIXED_RECONNECT_INTERVAL_MS: u64 = 5000; // 5 seconds fixed interval
 const SDK_NAME: &str = "laserstream-rust";
-const SDK_VERSION: &str = "0.1.9";
+const SDK_VERSION: &str = "0.1.10";
 
 /// Custom interceptor that adds SDK metadata headers to all gRPC requests
 #[derive(Clone)]
@@ -235,7 +235,15 @@ pub fn subscribe(
                                 // Merge the write_request into current_request so it persists across reconnections
                                 merge_subscribe_requests(&mut current_request, &write_request, &internal_slot_sub_id);
 
-                                if let Err(e) = sender.send(write_request).await {
+                                // Send the merged current_request (which preserves the internal slot
+                                // tracker) instead of the raw write_request. Yellowstone gRPC replaces
+                                // all subscriptions on each write, so the raw request would drop the
+                                // internal slot tracker and cause tracked_slot to go stale.
+                                let mut send_req = current_request.clone();
+                                send_req.from_slot = None;
+                                send_req.ping = None;
+
+                                if let Err(e) = sender.send(send_req).await {
                                     warn!(error = %e, "Failed to send write request");
                                     break;
                                 }


### PR DESCRIPTION
## Summary
- `write()` was sending the raw user request to the server, which replaced all subscriptions and silently dropped the internal slot tracker
- After a `write()`, `tracked_slot` would freeze until the next reconnect re-established the tracker, risking stale `from_slot` on reconnection
- Both Rust and JS SDKs now send the merged `current_request` (with the internal slot tracker preserved, `from_slot`/`ping` cleared) — matching the Go SDK fix from #86

## Test plan
- [x] Rust SDK compiles (`cargo check`)
- [x] JS SDK builds (`npm run build`)
- [x] Chaos proxy test: 5 disconnect cycles after `write()` — `tracked_slot` advances continuously, 0 stale-slot errors
- [x] Edge cases verified: single write, 5 rapid writes, write with user slot sub, long quiet period after write

🤖 Generated with [Claude Code](https://claude.com/claude-code)