### PR TITLE
Add plaintext http:// endpoint support to Go SDK

### DIFF
--- a/go/laserstream.go
+++ b/go/laserstream.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -32,7 +33,7 @@ const (
 // SDK metadata constants
 const (
 	SDKName    = "laserstream-go"
-	SDKVersion = "0.1.3"
+	SDKVersion = "0.1.4"
 )
 
 // Commitment levels
@@ -590,16 +591,24 @@ func (c *Client) connect(ctx context.Context) error {
 
 	// Handle production endpoint formats
 	var target string
+	// useInsecure is set when the endpoint uses the plaintext http:// scheme
+	// (e.g. http://localhost:4003 for the chaos proxy). Otherwise we use TLS.
+	useInsecure := false
 	if strings.HasPrefix(endpoint, "https://") || strings.HasPrefix(endpoint, "http://") {
-		// URL format (e.g., https://example.com or https://example.com:443)
+		// URL format (e.g., https://example.com or http://localhost:4003)
 		u, err := url.Parse(endpoint)
 		if err != nil {
 			return fmt.Errorf("error parsing endpoint URL: %w", err)
 		}
 
-		// Always use TLS and default HTTPS port
+		useInsecure = u.Scheme == "http"
+
+		// Use the explicit port if present, otherwise default to the
+		// scheme's standard port (80 for http, 443 for https).
 		if u.Port() != "" {
 			target = u.Host
+		} else if useInsecure {
+			target = u.Hostname() + ":80"
 		} else {
 			target = u.Hostname() + ":443"
 		}
@@ -615,8 +624,12 @@ func (c *Client) connect(ctx context.Context) error {
 	}
 
 	var opts []grpc.DialOption
-	creds := credentials.NewClientTLSFromCert(nil, "")
-	opts = append(opts, grpc.WithTransportCredentials(creds))
+	if useInsecure {
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	} else {
+		creds := credentials.NewClientTLSFromCert(nil, "")
+		opts = append(opts, grpc.WithTransportCredentials(creds))
+	}
 
 	// Apply channel options with defaults
 	channelOpts := c.config.ChannelOptions

--- a/go/preprocessed.go
+++ b/go/preprocessed.go
@@ -13,6 +13,7 @@ import (
 	pb "github.com/helius-labs/laserstream-sdk/go/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
@@ -138,13 +139,19 @@ func (c *PreprocessedClient) connectAndStream(ctx context.Context) error {
 	// Parse endpoint
 	endpoint := c.config.Endpoint
 	target := endpoint
+	// useInsecure is set when the endpoint uses the plaintext http:// scheme
+	// (e.g. http://localhost:4003 for the chaos proxy). Otherwise we use TLS.
+	useInsecure := false
 	if strings.HasPrefix(endpoint, "https://") || strings.HasPrefix(endpoint, "http://") {
 		u, err := url.Parse(endpoint)
 		if err != nil {
 			return fmt.Errorf("error parsing endpoint URL: %w", err)
 		}
+		useInsecure = u.Scheme == "http"
 		if u.Port() != "" {
 			target = u.Host
+		} else if useInsecure {
+			target = u.Hostname() + ":80"
 		} else {
 			target = u.Hostname() + ":443"
 		}
@@ -152,8 +159,12 @@ func (c *PreprocessedClient) connectAndStream(ctx context.Context) error {
 
 	// Create connection
 	var opts []grpc.DialOption
-	creds := credentials.NewClientTLSFromCert(nil, "")
-	opts = append(opts, grpc.WithTransportCredentials(creds))
+	if useInsecure {
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	} else {
+		creds := credentials.NewClientTLSFromCert(nil, "")
+		opts = append(opts, grpc.WithTransportCredentials(creds))
+	}
 
 	conn, err := grpc.DialContext(ctx, target, opts...)
 	if err != nil {


### PR DESCRIPTION
## Summary
The Go SDK hardcoded TLS credentials for every gRPC connection, so it could not connect to plaintext endpoints such as the chaos proxy at `http://localhost:4003` (the endpoint used in `.env` and `javascript/test-config.js`). This blocked chaos-proxy testing against the Go SDK.

This PR detects the endpoint scheme in both connection paths:
- **`Client.connect`** (`go/laserstream.go`)
- **`PreprocessedClient.connectAndStream`** (`go/preprocessed.go`)

Behavior:
- `http://` → dials with `insecure.NewCredentials()` (plaintext), default port `:80`
- `https://` → existing TLS credentials, default port `:443` (unchanged)
- bare `host:port` / bare hostname → TLS, default `:443` (unchanged)

This matches the JS/Rust core, where tonic treats `http://` as plaintext. Also bumps `SDKVersion` to `0.1.4` to prep for release (tag `go/v0.1.4`).

## Testing
Verified live through `go/test/chaos-proxy.go` (forwarding `:4003 → 208.91.110.241:4001`):

🤖 Generated with [Claude Code](https://claude.com/claude-code)