### PR TITLE
Release helius-laserstream 0.4.0 (Rust) + 0.6.0 (JS)

### DIFF
--- a/javascript/Cargo.lock
+++ b/javascript/Cargo.lock
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "laserstream-napi"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64 0.21.7",
  "bs58",

--- a/javascript/Cargo.toml
+++ b/javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laserstream-napi"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 [lib]

--- a/javascript/napi-src/stream.rs
+++ b/javascript/napi-src/stream.rs
@@ -23,7 +23,7 @@ const FORK_DEPTH_SAFETY_MARGIN: u64 = 31; // Max fork depth for processed commit
 
 // SDK metadata constants
 const SDK_NAME: &str = "laserstream-javascript";
-const SDK_VERSION: &str = "0.3.2";
+const SDK_VERSION: &str = "0.6.0";
 
 /// Custom interceptor that adds SDK metadata headers to all gRPC requests
 #[derive(Clone)]

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helius-laserstream",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "High-performance Laserstream gRPC client with automatic reconnection",
   "main": "client.js",
   "types": "client.d.ts",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -974,7 +974,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helius-laserstream"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-stream",
  "bs58",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helius-laserstream"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Helius <support@helius.xyz>"]
 description = "Rust client for Helius LaserStream gRPC with robust reconnection and slot tracking"

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -22,7 +22,7 @@ use laserstream_core_proto::geyser::{
 const HARD_CAP_RECONNECT_ATTEMPTS: u32 = (20 * 60) / 5; // 20 mins / 5 sec interval
 const FIXED_RECONNECT_INTERVAL_MS: u64 = 5000; // 5 seconds fixed interval
 const SDK_NAME: &str = "laserstream-rust";
-const SDK_VERSION: &str = "0.1.10";
+const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Custom interceptor that adds SDK metadata headers to all gRPC requests
 #[derive(Clone)]


### PR DESCRIPTION
Release both SDKs targeting the new token_accounts (ATA) transaction filter and laserstream-core-proto 9.3.0 (enum wire format).

## Rust — `helius-laserstream` 0.3.0 → 0.4.0
- Bumped via `cargo release minor`
- Published to crates.io: https://crates.io/crates/helius-laserstream/0.4.0
- Tag: `helius-laserstream-v0.4.0`
- SDK_VERSION header now sourced from `CARGO_PKG_VERSION` (was hardcoded `0.1.10`)

## JS — `helius-laserstream` 0.5.0 → 0.6.0
- `javascript/package.json` 0.5.0 → 0.6.0
- `javascript/Cargo.toml` (laserstream-napi) 0.5.0 → 0.6.0
- `javascript/napi-src/stream.rs` SDK_VERSION header 0.3.2 → 0.6.0

cc @hetdagli234 — SDK header now matches the package versions on both sides.

Note: the published Rust v0.4.0 still sends `x-sdk-version: 0.1.10` because the env!() fix landed after the publish. A v0.4.1 patch release will be needed post-merge so the wire header actually updates.