### PR TITLE
Release helius-laserstream 0.4.1 (Rust) (non_prod)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -974,7 +974,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helius-laserstream"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-stream",
  "bs58",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helius-laserstream"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Helius <support@helius.xyz>"]
 description = "Rust client for Helius LaserStream gRPC with robust reconnection and slot tracking"


### PR DESCRIPTION
Patch release so the on-the-wire `x-sdk-version` header reflects the actual crate version.

v0.4.0 was published before the `env!("CARGO_PKG_VERSION")` fix landed, so it still sends `x-sdk-version: 0.1.10`. v0.4.1 contains the same code as v0.4.0 plus the header fix.

Published to crates.io: https://crates.io/crates/helius-laserstream/0.4.1
Tag: `helius-laserstream-v0.4.1` (pending push)

Generated by `cargo release patch`.