### PR TITLE
Fix broken npm install: bump optionalDependencies + guard in CI (JS 0.6.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,7 +320,16 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: javascript
         run: |
-          # Publish main package (without .node files)
+          VERSION=$(node -p "require('./package.json').version")
+
+          # Pin optionalDependencies (platform packages) to the current version so
+          # npm installs the matching native binary. Drift here will silently break
+          # `npm install` on every release — the optional deps fail to resolve,
+          # `require('helius-laserstream')` throws "Cannot find module".
+          echo "🔧 Rewriting optionalDependencies to $VERSION"
+          jq --arg v "$VERSION" '.optionalDependencies |= with_entries(.value = $v)' \
+            package.json > package.json.tmp && mv package.json.tmp package.json
+
           echo "📤 Publishing main package helius-laserstream"
           npm publish || {
             echo "❌ Error: Failed to publish main package"

--- a/javascript/Cargo.lock
+++ b/javascript/Cargo.lock
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "laserstream-napi"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64 0.21.7",
  "bs58",

--- a/javascript/Cargo.toml
+++ b/javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laserstream-napi"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [lib]

--- a/javascript/napi-src/stream.rs
+++ b/javascript/napi-src/stream.rs
@@ -23,7 +23,7 @@ const FORK_DEPTH_SAFETY_MARGIN: u64 = 31; // Max fork depth for processed commit
 
 // SDK metadata constants
 const SDK_NAME: &str = "laserstream-javascript";
-const SDK_VERSION: &str = "0.6.0";
+const SDK_VERSION: &str = "0.6.1";
 
 /// Custom interceptor that adds SDK metadata headers to all gRPC requests
 #[derive(Clone)]

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helius-laserstream",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "High-performance Laserstream gRPC client with automatic reconnection",
   "main": "client.js",
   "types": "client.d.ts",
@@ -91,12 +91,12 @@
     }
   },
   "optionalDependencies": {
-    "helius-laserstream-darwin-arm64": "0.5.0",
-    "helius-laserstream-darwin-x64": "0.5.0",
-    "helius-laserstream-linux-arm64-gnu": "0.5.0",
-    "helius-laserstream-linux-arm64-musl": "0.5.0",
-    "helius-laserstream-linux-x64-gnu": "0.5.0",
-    "helius-laserstream-linux-x64-musl": "0.5.0"
+    "helius-laserstream-darwin-arm64": "0.6.1",
+    "helius-laserstream-darwin-x64": "0.6.1",
+    "helius-laserstream-linux-arm64-gnu": "0.6.1",
+    "helius-laserstream-linux-arm64-musl": "0.6.1",
+    "helius-laserstream-linux-x64-gnu": "0.6.1",
+    "helius-laserstream-linux-x64-musl": "0.6.1"
   },
   "dependencies": {
     "laserstream-core-proto-js": "^9.0.2",


### PR DESCRIPTION
## Bug

`helius-laserstream@0.6.0` on npm is **broken for any fresh install** on Linux (likely macOS too). Reproducer:

```
$ mkdir t && cd t && npm init -y && npm install helius-laserstream@0.6.0
$ node -e "require('helius-laserstream')"
Error: Cannot find module 'helius-laserstream-linux-x64-gnu'
```

The main package's `optionalDependencies` were pinned to `0.5.0` (stale — never bumped when the package version moved 0.5.0→0.6.0). On install, npm tries to resolve the platform binary at 0.5.0, fails (no 0.5.0 binary exists for 0.6.0), and silently moves on because optional deps are allowed to fail. At runtime the loader can't find the .node and throws.

Last working version on npm: **0.4.0**.

## Fix

1. Bump to **0.6.1** (`package.json`, `Cargo.toml` for laserstream-napi, `SDK_VERSION` header in stream.rs).
2. Set `optionalDependencies` to `0.6.1` to match.
3. **CI guard**: `.github/workflows/ci.yml` now rewrites `optionalDependencies` to the package version via `jq` right before `npm publish` of the main package. Without this, the same drift would happen again next release — optional deps fail silently so we'd never notice in CI.

## Verification

After merge + GitHub release `v0.6.1`:
```
$ npm install helius-laserstream@0.6.1
$ node -e "const x = require('helius-laserstream'); console.log(Object.keys(x))"
[ 'subscribe', 'subscribePreprocessed', 'CommitmentLevel', ... ]
```