### PR TITLE
JS: default maxReconnectAttempts to 240 (match Go/Rust)

### DIFF
--- a/javascript/napi-src/client.rs
+++ b/javascript/napi-src/client.rs
@@ -240,7 +240,7 @@ impl ClientInner {
         Ok(Self {
             endpoint,
             token,
-            max_reconnect_attempts: max_reconnect_attempts.unwrap_or(120),
+            max_reconnect_attempts: max_reconnect_attempts.unwrap_or(240),
             channel_options,
             // Default to true (replay enabled) unless explicitly set to false
             replay: replay.unwrap_or(true),


### PR DESCRIPTION
## What
Change the Node NAPI client's default `maxReconnectAttempts` from **120** to **240**.

## Why
The JS SDK defaulted to 120 attempts (~10 min at the fixed 5s reconnect interval), while the **Go and Rust SDKs default to the 240-attempt hard cap (~20 min)**. This made the JS reconnect window half that of the other SDKs for no clear reason. Aligning all three gives consistent recovery behavior across SDKs.

- `napi-src/client.rs`: `max_reconnect_attempts.unwrap_or(120)` → `unwrap_or(240)`
- Still bounded by `HARD_CAP_RECONNECT_ATTEMPTS = 240`, so 240 is the cap either way.
- Users who pass an explicit `maxReconnectAttempts` are unaffected.

## Testing
Verified against the chaos proxy (`laserstreamChaosProxy.ts`): the SDK reconnects + replays from `tracked_slot − 31` (processed) across repeated server-side disconnects; rebuilt the NAPI addon (compiles clean). The cap only changes how long the client keeps retrying before surfacing a terminal error to the consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)