### PR TITLE
Rust: suppress transient reconnect errors (match JS/Go error contract)

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -218,9 +218,12 @@ pub fn subscribe(
                                             }
                                         }
                                         Err(status) => {
-                                            // Yield the error to consumer AND continue with reconnection
+                                            // Transient stream error: log and reconnect silently. Per the SDK
+                                            // error contract, reconnect failures are NOT surfaced to the
+                                            // consumer — an error is only yielded once reconnection ultimately
+                                            // fails (max attempts reached, see the Err(err) arm below). This
+                                            // matches subscribe_preprocessed and the Go/JS SDKs.
                                             warn!(error = %status, "Stream error, will reconnect after 5s delay");
-                                            yield Err(LaserstreamError::Status(status.clone()));
                                             break;
                                         }
                                     }

--- a/rust/test/subscription_replacement_persistence.rs
+++ b/rust/test/subscription_replacement_persistence.rs
@@ -139,6 +139,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let deadline = Instant::now() + Duration::from_secs(180);
 
+    // Reconnects are no longer surfaced as stream errors (the SDK suppresses
+    // them until max attempts are exhausted), so detect a reconnect by a gap in
+    // the data stream: data stops while the proxy is offline, then resumes once
+    // the client reconnects. A >4s silence (proxy down 5-7s + reconnect) = one.
+    let gap_threshold = Duration::from_secs(4);
+    let mut last_update = Instant::now();
+    let mut in_gap = false;
+    let mut seen_first = false;
+
     while Instant::now() < deadline {
         // Early exit: Phase 3 has enough messages
         let p3_total = usdc_phase3.load(Ordering::Relaxed) + usdt_phase3.load(Ordering::Relaxed);
@@ -151,6 +160,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Some(result) = stream.next() => {
                 match result {
                     Ok(update) => {
+                        last_update = Instant::now();
+                        in_gap = false;
+                        seen_first = true;
                         if let Some(UpdateOneof::Transaction(_)) = &update.update_oneof {
                             let now = Instant::now();
                             let write_time = *write_completed_time.lock().await;
@@ -185,21 +197,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         }
                     }
                     Err(e) => {
-                        let recon_num = total_reconnects.fetch_add(1, Ordering::SeqCst) + 1;
-                        let write_time = *write_completed_time.lock().await;
-
-                        if write_time.is_some() {
-                            let n = reconnects_after_write.fetch_add(1, Ordering::SeqCst) + 1;
-                            reconnected_after_write.store(true, Ordering::SeqCst);
-                            *reconnect_after_write_time.lock().await = Some(Instant::now());
-                            eprintln!("[reconnect #{}] (after write, #{} post-write) {}", recon_num, n, e);
-                        } else {
-                            eprintln!("[reconnect #{}] (before write) {}", recon_num, e);
-                        }
+                        // With the new error contract this only fires if reconnection
+                        // ultimately failed (max attempts exhausted) — treat as terminal.
+                        eprintln!("[terminal error] stream yielded error: {}", e);
+                        break;
                     }
                 }
             }
-            _ = sleep(Duration::from_millis(100)) => {}
+            _ = sleep(Duration::from_millis(100)) => {
+                // Gap-based reconnect detection (see note above the loop).
+                let now = Instant::now();
+                if seen_first && !in_gap && now.duration_since(last_update) > gap_threshold {
+                    in_gap = true;
+                    let gap_s = now.duration_since(last_update).as_secs_f64();
+                    let recon_num = total_reconnects.fetch_add(1, Ordering::SeqCst) + 1;
+                    let write_time = *write_completed_time.lock().await;
+                    if write_time.is_some() {
+                        let n = reconnects_after_write.fetch_add(1, Ordering::SeqCst) + 1;
+                        reconnected_after_write.store(true, Ordering::SeqCst);
+                        *reconnect_after_write_time.lock().await = Some(now);
+                        eprintln!("[reconnect #{}] (after write, #{} post-write) data gap {:.1}s", recon_num, n, gap_s);
+                    } else {
+                        eprintln!("[reconnect #{}] (before write) data gap {:.1}s", recon_num, gap_s);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## What
`subscribe()` no longer yields a transient error to the consumer on each mid-stream disconnect. It now logs the error and reconnects silently, surfacing an error **only when reconnection ultimately fails** (max attempts exhausted).

## Why
The Rust `subscribe()` was the odd one out: it yielded `LaserstreamError::Status` to the consumer on every drop before reconnecting, so a Rust consumer saw transient errors on every blip. The **Go and JS SDKs** — and **`subscribe_preprocessed()` in this same file** — suppress reconnect failures and only surface an error after exhausting all attempts. This aligns `subscribe()` with that contract: the customer is only notified if the internal reconnect logic gives up.

```diff
  Err(status) => {
-     warn!(error = %status, "Stream error, will reconnect after 5s delay");
-     yield Err(LaserstreamError::Status(status.clone()));
+     // Transient stream error: log and reconnect silently. Errors are only
+     // surfaced once reconnection ultimately fails (max attempts) — matches
+     // subscribe_preprocessed and the Go/JS SDKs.
+     warn!(error = %status, "Stream error, will reconnect after 5s delay");
      break;
  }
```
The terminal `LaserstreamError::MaxReconnectAttempts` yield (after max attempts) is unchanged.

## Test update
`test/subscription_replacement_persistence.rs` previously detected a reconnect by catching that yielded error. Since transient errors are no longer surfaced, it now detects a reconnect by a **gap in the data stream** (data stops while the proxy is offline, then resumes after reconnect) — the same approach used to validate the JS/Go SDKs.

## Verification
Re-ran against the chaos proxy (`laserstreamChaosProxy.ts`) after the change:
```
[reconnect #1] (after write, #1 post-write) data gap 4.1s
Phase 1 (before write):                USDC=119    USDT=0
Phase 2 (after write, pre-reconnect):  USDC=0      USDT=0
Phase 3 (after reconnect post-write):  USDC=0      USDT=5
All assertions passed — write() persisted across 1 post-write reconnection(s)
```
Reconnection + replay + write-persistence still work; the consumer just no longer sees the transient error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)