### PR TITLE
test: reconnect/replay verification harnesses (JS + Go)

### DIFF
--- a/go/test/reconnect-persistence-verify.go
+++ b/go/test/reconnect-persistence-verify.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	laserstream "github.com/helius-labs/laserstream-sdk/go"
+	"github.com/joho/godotenv"
+)
+
+// Direct verification of Go reconnect + replay + write-persistence through the
+// chaos proxy. Mirrors the JS reconnect-replay-verify harness. The SDK only
+// surfaces errors to the callback after exhausting all retries, so we detect
+// reconnect windows via data gaps and verify the last write() persists across them.
+//
+//	LASERSTREAM_ENDPOINT=http://localhost:4003 LASERSTREAM_API_KEY=... \
+//	  go run test/reconnect-persistence-verify.go
+const (
+	USDC = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+	USDT = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"
+)
+
+func main() {
+	godotenv.Load("../.env")
+	endpoint := os.Getenv("LASERSTREAM_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "http://localhost:4003"
+	}
+	apiKey := os.Getenv("LASERSTREAM_API_KEY")
+
+	runMs := 110000
+	writeAtMs := 10000
+	postWriteGraceMs := int64(8000)
+
+	var mu sync.Mutex
+	var maxSlot uint64
+	lastDataAt := time.Now()
+	var writeAt time.Time
+	gaps := 0
+	postWriteReconnects := 0
+	rewindsAfterReconnect := 0
+	inGap := false
+	var firstPostWriteGapAt time.Time
+
+	type fEntry struct {
+		t       time.Time
+		filters []string
+	}
+	var txTimeline []fEntry
+
+	client := laserstream.NewClient(laserstream.LaserstreamConfig{Endpoint: endpoint, APIKey: apiKey})
+
+	commit := laserstream.CommitmentLevel_PROCESSED
+	fbc := true
+	isu := false
+	voteF := false
+
+	req := &laserstream.SubscribeRequest{
+		Transactions: map[string]*laserstream.SubscribeRequestFilterTransactions{
+			"usdc": {Vote: &voteF, Failed: &voteF, AccountInclude: []string{USDC}},
+		},
+		Slots:      map[string]*laserstream.SubscribeRequestFilterSlots{"slots": {FilterByCommitment: &fbc, InterslotUpdates: &isu}},
+		Commitment: &commit,
+	}
+
+	dataCb := func(u *laserstream.SubscribeUpdate) {
+		mu.Lock()
+		defer mu.Unlock()
+		now := time.Now()
+		since := now.Sub(lastDataAt).Seconds()
+		if since > 4 {
+			gaps++
+			inGap = true
+			sinceWrite := int64(-1)
+			if !writeAt.IsZero() {
+				sinceWrite = now.Sub(writeAt).Milliseconds()
+			}
+			if sinceWrite > postWriteGraceMs {
+				postWriteReconnects++
+				if firstPostWriteGapAt.IsZero() {
+					firstPostWriteGapAt = now
+				}
+			}
+			fmt.Printf("[gap] data resumed after %.1fs silence (reconnect window #%d)\n", since, gaps)
+		}
+		lastDataAt = now
+
+		switch up := u.UpdateOneof.(type) {
+		case *laserstream.SubscribeUpdate_Slot:
+			if up.Slot != nil {
+				s := up.Slot.Slot
+				if s != 0 && maxSlot != 0 && s < maxSlot-1 {
+					if inGap {
+						rewindsAfterReconnect++
+						fmt.Printf("[replay] slot rewound %d -> %d (Δ%d) after reconnect\n", maxSlot, s, maxSlot-s)
+						inGap = false
+					}
+				}
+				if s > maxSlot {
+					maxSlot = s
+				}
+			}
+		case *laserstream.SubscribeUpdate_Transaction:
+			txTimeline = append(txTimeline, fEntry{t: now, filters: u.Filters})
+		}
+	}
+	errCb := func(err error) { fmt.Printf("[onError callback] %v\n", err) }
+
+	if err := client.Subscribe(req, dataCb, errCb); err != nil {
+		fmt.Printf("subscribe failed: %v\n", err)
+		os.Exit(2)
+	}
+
+	time.Sleep(time.Duration(writeAtMs) * time.Millisecond)
+	fmt.Println("[write] replacing USDC filter with USDT...")
+	writeReq := &laserstream.SubscribeRequest{
+		Transactions: map[string]*laserstream.SubscribeRequestFilterTransactions{
+			"usdt": {Vote: &voteF, Failed: &voteF, AccountInclude: []string{USDT}},
+		},
+		Slots:      map[string]*laserstream.SubscribeRequestFilterSlots{"slots": {FilterByCommitment: &fbc, InterslotUpdates: &isu}},
+		Commitment: &commit,
+	}
+	if err := client.Write(writeReq); err != nil {
+		fmt.Printf("write failed: %v\n", err)
+		os.Exit(2)
+	}
+	mu.Lock()
+	writeAt = time.Now()
+	mu.Unlock()
+
+	time.Sleep(time.Duration(runMs-writeAtMs) * time.Millisecond)
+	client.Close()
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	flat := func(pred func(fEntry) bool) map[string]bool {
+		set := map[string]bool{}
+		for _, e := range txTimeline {
+			if pred(e) {
+				for _, f := range e.filters {
+					set[f] = true
+				}
+			}
+		}
+		return set
+	}
+	fb := flat(func(e fEntry) bool { return !writeAt.IsZero() && e.t.Before(writeAt) })
+	fa := flat(func(e fEntry) bool {
+		return !writeAt.IsZero() && e.t.After(writeAt.Add(time.Duration(postWriteGraceMs)*time.Millisecond))
+	})
+	far := flat(func(e fEntry) bool {
+		return !firstPostWriteGapAt.IsZero() && e.t.After(firstPostWriteGapAt.Add(2*time.Second))
+	})
+
+	fmt.Println("\n================ GO RECONNECT/REPLAY VERIFICATION ================")
+	fmt.Printf("run duration:                 %ds\n", runMs/1000)
+	fmt.Printf("reconnect windows (gaps>4s):  %d  (post-write: %d)\n", gaps, postWriteReconnects)
+	fmt.Printf("replay rewinds after reconnect: %d\n", rewindsAfterReconnect)
+	fmt.Printf("max slot reached:             %d\n", maxSlot)
+	fmt.Printf("tx filters BEFORE write:      %v\n", keys(fb))
+	fmt.Printf("tx filters AFTER write+grace: %v\n", keys(fa))
+	fmt.Printf("tx filters AFTER reconnect:   %v\n", keys(far))
+	fmt.Println("---------------------------------------------------------------")
+
+	allPass := true
+	check := func(name string, ok bool) {
+		if !ok {
+			allPass = false
+		}
+		st := "PASS"
+		if !ok {
+			st = "FAIL"
+		}
+		fmt.Printf("  %s  %s\n", st, name)
+	}
+	check("USDC flowed before write", fb["usdc"])
+	check("write replaced USDC->USDT (no USDC after write+grace)", !fa["usdc"] && fa["usdt"])
+	check("at least one reconnect window observed", gaps > 0)
+	check("replay rewind observed after a reconnect", rewindsAfterReconnect > 0)
+	if postWriteReconnects > 0 {
+		check("write persisted after reconnect (USDT present, USDC absent)", far["usdt"] && !far["usdc"])
+	} else {
+		fmt.Println("NOTE: no post-write reconnect occurred; write-persistence-across-reconnect not exercised.")
+	}
+	fmt.Println("===============================================================")
+	if allPass {
+		fmt.Println("RESULT: PASS")
+		os.Exit(0)
+	}
+	fmt.Println("RESULT: FAIL")
+	os.Exit(1)
+}
+
+func keys(m map[string]bool) []string {
+	out := []string{}
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/javascript/test/chaosProxyConfigurable.ts
+++ b/javascript/test/chaosProxyConfigurable.ts
@@ -1,0 +1,63 @@
+import net from 'net';
+import { randomInt } from 'crypto';
+const cfg = require('../test-config');
+
+/*
+ * Configurable variant of laserstreamChaosProxy.ts — identical proxying logic,
+ * but online/offline windows + listen port are env-driven so tests can drive
+ * reconnect/replay deterministically. Defaults match the original proxy.
+ *
+ *   CHAOS_LOCAL_PORT  (default 4003)
+ *   CHAOS_MIN_UP / CHAOS_MAX_UP  online window ms (default 20000 / 60000)
+ *   CHAOS_MIN_DN / CHAOS_MAX_DN  offline window ms (default 5000 / 30000)
+ *   CHAOS_FIRST_UP    ms before the very first flip (default = random MIN_UP..MAX_UP)
+ */
+const LOCAL_PORT  = Number(process.env.CHAOS_LOCAL_PORT  ?? cfg.localProxyPort ?? 4003);
+const REMOTE_HOST = cfg.proxy.endpoint;
+const REMOTE_PORT = cfg.proxy.port;
+
+const MIN_UP = Number(process.env.CHAOS_MIN_UP ?? 20_000);
+const MAX_UP = Number(process.env.CHAOS_MAX_UP ?? 60_000);
+const MIN_DN = Number(process.env.CHAOS_MIN_DN ?? 5_000);
+const MAX_DN = Number(process.env.CHAOS_MAX_DN ?? 30_000);
+const FIRST_UP = process.env.CHAOS_FIRST_UP ? Number(process.env.CHAOS_FIRST_UP) : randomInt(MIN_UP, MAX_UP);
+
+let online  = true;
+let flipAt  = Date.now() + FIRST_UP;
+const live  : net.Socket[] = [];
+const ts = () => new Date().toISOString().slice(11, 23);
+
+function flip() {
+  const now = Date.now();
+  if (now >= flipAt) {
+    online = !online;
+    const dwell = randomInt(online ? MIN_UP : MIN_DN, online ? MAX_UP : MAX_DN);
+    console.log(`[proxy ${ts()}] ⇆  ${online ? 'ONLINE' : 'OFFLINE'} (for ~${Math.round(dwell/1000)}s, killed ${online ? 0 : live.length} conns)`);
+    if (!online) live.splice(0).forEach(s => s.destroy());
+    flipAt = now + dwell;
+  }
+  setTimeout(flip, 250);
+}
+console.log(`[proxy ${ts()}] windows: UP ${MIN_UP/1000}-${MAX_UP/1000}s, DOWN ${MIN_DN/1000}-${MAX_DN/1000}s, first flip in ${Math.round(FIRST_UP/1000)}s`);
+flip();
+
+net.createServer(client => {
+  if (!online) { client.destroy(); return; }
+
+  const upstream = net.connect({ host: REMOTE_HOST, port: REMOTE_PORT },
+    () => console.log(`[proxy ${ts()}] → upstream connected`));
+
+  client.setNoDelay(true);  upstream.setNoDelay(true);
+  client.pipe(upstream);  upstream.pipe(client);
+
+  live.push(client, upstream);
+  const clean = () => {
+    client.destroy(); upstream.destroy();
+    [client, upstream].forEach(s => {
+      const i = live.indexOf(s); if (i !== -1) live.splice(i, 1);
+    });
+  };
+  client   .on('error', clean).on('close', clean);
+  upstream .on('error', clean).on('close', clean);
+}).listen(LOCAL_PORT, () =>
+  console.log(`[proxy ${ts()}] listening on localhost:${LOCAL_PORT} → ${REMOTE_HOST}:${REMOTE_PORT}`));

--- a/javascript/test/reconnect-replay-verify.ts
+++ b/javascript/test/reconnect-replay-verify.ts
@@ -1,0 +1,133 @@
+import { subscribe, CommitmentLevel, SubscribeUpdate, LaserstreamConfig } from '../client';
+const cfg = require('../test-config');
+
+const USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const USDT = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB';
+
+/*
+ * Direct verification of JS reconnect + replay + write-persistence.
+ * The stock JS tests detect reconnects via an error callback that never fires
+ * (SDK only calls back after 240 attempts), so this harness observes behavior directly:
+ *   - slot stream → detect replay rewind (slot goes backwards ~31 after a gap)
+ *   - data gaps   → count reconnect windows
+ *   - tx filters over time → confirm the last write() persists after a reconnect
+ * Correlate with the SDK's stderr "RECONNECT:" lines (captured to a file by the runner).
+ */
+const RUN_MS = Number(process.env.RUN_MS ?? 110_000);
+const WRITE_AT_MS = 10_000;
+const REPLAY = process.env.REPLAY !== 'false';   // default true; set REPLAY=false to test replay-disabled
+
+async function main() {
+  console.log(`[config] replay=${REPLAY}`);
+  const config: LaserstreamConfig = {
+    apiKey: cfg.laserstream.apiKey,
+    endpoint: cfg.laserstream.endpoint,
+    replay: REPLAY,
+  };
+
+  let maxSlot = 0;
+  let lastDataAt = Date.now();
+  let writeAt = 0;
+  const gaps: { at: number; sinceWriteMs: number }[] = [];      // reconnect windows (data resumed after >4s silence)
+  const rewinds: { fromMax: number; to: number; afterGap: boolean }[] = [];
+  const txFilterTimeline: { t: number; filters: string[] }[] = [];
+  let inGap = false;
+
+  const stream = await subscribe(
+    config,
+    {
+      transactions: { 'usdc': { vote: false, failed: false, accountInclude: [USDC], accountExclude: [], accountRequired: [] } },
+      slots: { 'slots': { filterByCommitment: true, interslotUpdates: false } },
+      commitment: CommitmentLevel.PROCESSED,
+      accounts: {}, transactionsStatus: {}, blocks: {}, blocksMeta: {}, entry: {}, accountsDataSlice: [],
+    },
+    async (u: SubscribeUpdate) => {
+      const now = Date.now();
+      const sinceData = now - lastDataAt;
+      if (sinceData > 4000 && lastDataAt > 0) {
+        gaps.push({ at: now, sinceWriteMs: writeAt ? now - writeAt : -1 });
+        inGap = true;
+        console.log(`[gap] data resumed after ${(sinceData / 1000).toFixed(1)}s silence (reconnect window #${gaps.length})`);
+      }
+      lastDataAt = now;
+
+      if ((u as any).slot) {
+        const s = Number((u as any).slot.slot);
+        if (s && maxSlot && s < maxSlot - 1) {
+          rewinds.push({ fromMax: maxSlot, to: s, afterGap: inGap });
+          console.log(`[replay] slot rewound ${maxSlot} -> ${s} (Δ${maxSlot - s})${inGap ? ' after reconnect' : ''}`);
+          inGap = false;
+        }
+        if (s > maxSlot) maxSlot = s;
+      }
+      if (u.transaction) {
+        const filters = u.filters || [];
+        txFilterTimeline.push({ t: now, filters });
+      }
+    },
+    (err) => { console.log(`[onError callback] ${err.message}`); }
+  );
+
+  await new Promise(r => setTimeout(r, WRITE_AT_MS));
+  console.log('[write] replacing USDC filter with USDT...');
+  await stream.write({
+    transactions: { 'usdt': { vote: false, failed: false, accountInclude: [USDT], accountExclude: [], accountRequired: [] } },
+    slots: { 'slots': { filterByCommitment: true, interslotUpdates: false } },
+    commitment: CommitmentLevel.PROCESSED,
+    accounts: {}, transactionsStatus: {}, blocks: {}, blocksMeta: {}, entry: {}, accountsDataSlice: [],
+  });
+  writeAt = Date.now();
+
+  await new Promise(r => setTimeout(r, RUN_MS - WRITE_AT_MS));
+  stream.cancel();
+
+  // ---- Analysis ----
+  const POST_WRITE_GRACE = 8000;
+  const beforeWrite = txFilterTimeline.filter(e => writeAt && e.t < writeAt);
+  const afterWrite = txFilterTimeline.filter(e => writeAt && e.t > writeAt + POST_WRITE_GRACE);
+  const flat = (arr: typeof txFilterTimeline) => new Set(arr.flatMap(e => e.filters));
+  const fb = flat(beforeWrite), fa = flat(afterWrite);
+
+  // Reconnects that happened AFTER the write (the persistence-relevant ones)
+  const postWriteReconnects = gaps.filter(g => g.sinceWriteMs > POST_WRITE_GRACE).length;
+  // tx filters seen only in windows that begin after a post-write reconnect
+  const firstPostWriteGapAt = gaps.find(g => g.sinceWriteMs > POST_WRITE_GRACE)?.at ?? 0;
+  const afterReconnect = firstPostWriteGapAt
+    ? txFilterTimeline.filter(e => e.t > firstPostWriteGapAt + 2000)
+    : [];
+  const far = flat(afterReconnect);
+
+  console.log('\n================ JS RECONNECT/REPLAY VERIFICATION ================');
+  console.log(`run duration:                 ${RUN_MS / 1000}s`);
+  console.log(`reconnect windows (gaps>4s):  ${gaps.length}  (post-write: ${postWriteReconnects})`);
+  console.log(`replay rewinds observed:      ${rewinds.length}  (after a reconnect: ${rewinds.filter(r => r.afterGap).length})`);
+  console.log(`max slot reached:             ${maxSlot}`);
+  console.log(`tx filters BEFORE write:      [${[...fb].join(', ') || '(none)'}]`);
+  console.log(`tx filters AFTER write+grace: [${[...fa].join(', ') || '(none)'}]`);
+  console.log(`tx filters AFTER reconnect:   [${[...far].join(', ') || '(none)'}]`);
+
+  // ---- Verdicts ----
+  const checks: [string, boolean][] = [];
+  checks.push(['USDC flowed before write', fb.has('usdc')]);
+  checks.push(['write replaced USDC->USDT (no USDC after write+grace)', !fa.has('usdc') && fa.has('usdt')]);
+  checks.push(['at least one reconnect window observed', gaps.length > 0]);
+  if (REPLAY) {
+    checks.push(['replay rewind observed after a reconnect', rewinds.some(r => r.afterGap)]);
+  } else {
+    checks.push(['replay DISABLED: no rewind after reconnect (resumes at live tip)', !rewinds.some(r => r.afterGap)]);
+  }
+  if (postWriteReconnects > 0) {
+    checks.push(['write persisted after reconnect (USDT present, USDC absent)', far.has('usdt') && !far.has('usdc')]);
+  } else {
+    console.log('NOTE: no post-write reconnect occurred in this run; write-persistence-across-reconnect not exercised.');
+  }
+
+  console.log('---------------------------------------------------------------');
+  let allPass = true;
+  for (const [name, ok] of checks) { console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}`); if (!ok) allPass = false; }
+  console.log('===============================================================');
+  console.log(allPass ? 'RESULT: PASS' : 'RESULT: FAIL');
+  process.exit(allPass ? 0 : 1);
+}
+
+main().catch(e => { console.error('harness error:', e); process.exit(2); });


### PR DESCRIPTION
## Why
The existing JS reconnection tests detect a reconnect by matching the error callback for `'Connection error'` + `'attempt 1'`. But the SDK **intentionally** only surfaces an error to the consumer once reconnection ultimately fails (max attempts) — per-attempt reconnects go to stderr only, and the string `"Connection error"` isn't even produced. So those tests can't observe a normal reconnect: they print *"chaos proxy may not be running"* and pass without asserting anything, **even while reconnects are actively happening**.

These harnesses verify reconnect + replay + write-persistence **by observed behavior**, not by a surfaced error.

## What
- **`javascript/test/reconnect-replay-verify.ts`** — subscribes to USDC txns + slots, `write()`s to USDT mid-stream, runs ~110s through the chaos proxy, and checks:
  - reconnect windows via data-stream gaps
  - replay via the processed-commitment slot rewind (`tracked_slot − 31`)
  - the `write()` (USDT) persists across every reconnect (USDC never returns)
  - `REPLAY=false` toggle asserts no rewind when replay is disabled
- **`go/test/reconnect-persistence-verify.go`** — the same harness for the Go SDK (fills its missing write-persistence-across-reconnect coverage).
- **`javascript/test/chaosProxyConfigurable.ts`** — env-tunable copy of `laserstreamChaosProxy.ts` (`CHAOS_MIN_UP/MAX_UP/MIN_DN/MAX_DN/FIRST_UP/LOCAL_PORT`; defaults identical) so tests can drive reconnects deterministically instead of waiting on the stock 20–60s random window. Original proxy left untouched.

## How to run
```bash
# terminal 1 — proxy
cd javascript && CHAOS_MIN_UP=25000 CHAOS_MAX_UP=32000 CHAOS_MIN_DN=5000 CHAOS_MAX_DN=7000 \
  npx ts-node test/chaosProxyConfigurable.ts
# terminal 2 — JS
cd javascript && npx ts-node test/reconnect-replay-verify.ts
# terminal 2 — Go
cd go && LASERSTREAM_ENDPOINT=http://localhost:4003 LASERSTREAM_API_KEY=<key> \
  go run test/reconnect-persistence-verify.go
```

## Verified
Both pass against the chaos proxy — e.g. JS: 3 post-write reconnects, replay rewind `tracked_slot=426906638 → 426906607` (Δ31), filters `[usdc] → [usdt] → [usdt]`; Go: equivalent. Credentials come from the existing `test-config.js` / `.env` (gitignored), same as the other tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)