### PR TITLE
Reconnection consistency: align JS/Rust contract + verification harnesses

### DIFF
--- a/go/test/reconnect-persistence-verify.go
+++ b/go/test/reconnect-persistence-verify.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	laserstream "github.com/helius-labs/laserstream-sdk/go"
+	"github.com/joho/godotenv"
+)
+
+// Observes reconnect (data gap), replay (processed slot rewind ~31) and that a
+// write() persists across reconnects — the stock tests can't see reconnects
+// since the SDK only surfaces errors after max attempts. Needs the chaos proxy.
+const (
+	usdc = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+	usdt = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"
+)
+
+type ev struct {
+	t time.Time
+	f []string
+}
+
+func main() {
+	godotenv.Load("../.env")
+	endpoint := os.Getenv("LASERSTREAM_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "http://localhost:4003"
+	}
+	client := laserstream.NewClient(laserstream.LaserstreamConfig{Endpoint: endpoint, APIKey: os.Getenv("LASERSTREAM_API_KEY")})
+
+	commit := laserstream.CommitmentLevel_PROCESSED
+	no, fbc := false, true
+	req := func(mint, id string) *laserstream.SubscribeRequest {
+		return &laserstream.SubscribeRequest{
+			Transactions: map[string]*laserstream.SubscribeRequestFilterTransactions{id: {Vote: &no, Failed: &no, AccountInclude: []string{mint}}},
+			Slots:        map[string]*laserstream.SubscribeRequestFilterSlots{"slots": {FilterByCommitment: &fbc}},
+			Commitment:   &commit,
+		}
+	}
+
+	var mu sync.Mutex
+	var maxSlot uint64
+	last, gaps, rewinds, inGap := time.Now(), 0, 0, false
+	var writeAt, firstGapAfterWrite time.Time
+	var txAt []ev
+
+	dataCb := func(u *laserstream.SubscribeUpdate) {
+		mu.Lock()
+		defer mu.Unlock()
+		now := time.Now()
+		if now.Sub(last) > 4*time.Second {
+			gaps++
+			inGap = true
+			if !writeAt.IsZero() && now.Sub(writeAt) > 8*time.Second && firstGapAfterWrite.IsZero() {
+				firstGapAfterWrite = now
+			}
+			fmt.Printf("[gap] reconnect window #%d\n", gaps)
+		}
+		last = now
+		switch up := u.UpdateOneof.(type) {
+		case *laserstream.SubscribeUpdate_Slot:
+			if up.Slot != nil {
+				s := up.Slot.Slot
+				if maxSlot != 0 && s < maxSlot-1 && inGap {
+					rewinds++
+					fmt.Printf("[replay] rewind %d->%d (Δ%d)\n", maxSlot, s, maxSlot-s)
+					inGap = false
+				}
+				if s > maxSlot {
+					maxSlot = s
+				}
+			}
+		case *laserstream.SubscribeUpdate_Transaction:
+			txAt = append(txAt, ev{now, u.Filters})
+		}
+	}
+
+	if err := client.Subscribe(req(usdc, "usdc"), dataCb, func(error) {}); err != nil {
+		fmt.Println("subscribe failed:", err)
+		os.Exit(2)
+	}
+
+	// write only once data is flowing (live connection) so it isn't lost mid-disconnect;
+	// a later reconnect then exercises persistence
+	for i := 0; i < 80; i++ {
+		mu.Lock()
+		n := len(txAt)
+		mu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	time.Sleep(2 * time.Second)
+	fmt.Println("[write] USDC -> USDT")
+	if err := client.Write(req(usdt, "usdt")); err != nil {
+		fmt.Println("write failed:", err)
+		os.Exit(2)
+	}
+	mu.Lock()
+	writeAt = time.Now()
+	mu.Unlock()
+
+	time.Sleep(90 * time.Second)
+	client.Close()
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	set := func(pred func(time.Time) bool) map[string]bool {
+		m := map[string]bool{}
+		for _, e := range txAt {
+			if pred(e.t) {
+				for _, f := range e.f {
+					m[f] = true
+				}
+			}
+		}
+		return m
+	}
+	before := set(func(t time.Time) bool { return t.Before(writeAt) })
+	after := set(func(t time.Time) bool { return t.After(writeAt.Add(8 * time.Second)) })
+	afterRecon := map[string]bool{}
+	if !firstGapAfterWrite.IsZero() {
+		afterRecon = set(func(t time.Time) bool { return t.After(firstGapAfterWrite.Add(2 * time.Second)) })
+	}
+
+	fmt.Printf("\nreconnects=%d rewinds=%d maxSlot=%d\n", gaps, rewinds, maxSlot)
+	ok := true
+	check := func(name string, pass bool) {
+		ok = ok && pass
+		s := "PASS"
+		if !pass {
+			s = "FAIL"
+		}
+		fmt.Printf("  %s  %s\n", s, name)
+	}
+	check("USDC before write", before["usdc"])
+	check("write replaced USDC->USDT", !after["usdc"] && after["usdt"])
+	check("reconnect observed", gaps > 0)
+	check("replay rewind after reconnect", rewinds > 0)
+	if !firstGapAfterWrite.IsZero() {
+		check("write persisted after reconnect", afterRecon["usdt"] && !afterRecon["usdc"])
+	}
+	if ok {
+		fmt.Println("RESULT: PASS")
+		os.Exit(0)
+	}
+	fmt.Println("RESULT: FAIL")
+	os.Exit(1)
+}

--- a/javascript/napi-src/client.rs
+++ b/javascript/napi-src/client.rs
@@ -240,7 +240,7 @@ impl ClientInner {
         Ok(Self {
             endpoint,
             token,
-            max_reconnect_attempts: max_reconnect_attempts.unwrap_or(120),
+            max_reconnect_attempts: max_reconnect_attempts.unwrap_or(240),
             channel_options,
             // Default to true (replay enabled) unless explicitly set to false
             replay: replay.unwrap_or(true),

--- a/javascript/test/reconnect-replay-verify.ts
+++ b/javascript/test/reconnect-replay-verify.ts
@@ -1,0 +1,71 @@
+import { subscribe, CommitmentLevel, SubscribeUpdate, LaserstreamConfig } from '../client';
+const cfg = require('../test-config');
+
+const USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const USDT = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB';
+
+// Observes reconnect (data gap), replay (processed slot rewind ~31) and that a
+// write() persists across reconnects — the stock tests can't see reconnects
+// since the SDK only surfaces errors after max attempts. Needs the chaos proxy.
+const RUN_MS = Number(process.env.RUN_MS ?? 90_000);   // run window after the write()
+const REPLAY = process.env.REPLAY !== 'false';
+
+async function main() {
+  const config: LaserstreamConfig = { apiKey: cfg.laserstream.apiKey, endpoint: cfg.laserstream.endpoint, replay: REPLAY };
+  const slotsMap = { slots: { filterByCommitment: true, interslotUpdates: false } };
+  const req = (mint: string, id: string) => ({
+    transactions: { [id]: { vote: false, failed: false, accountInclude: [mint], accountExclude: [], accountRequired: [] } },
+    slots: slotsMap, commitment: CommitmentLevel.PROCESSED,
+    accounts: {}, transactionsStatus: {}, blocks: {}, blocksMeta: {}, entry: {}, accountsDataSlice: [],
+  });
+
+  let maxSlot = 0, last = Date.now(), writeAt = 0, gaps = 0, rewinds = 0, inGap = false, firstGapAfterWrite = 0;
+  const txAt: { t: number; f: string[] }[] = [];
+
+  const stream = await subscribe(config, req(USDC, 'usdc'), async (u: SubscribeUpdate) => {
+    const now = Date.now();
+    if (now - last > 4000) {
+      gaps++; inGap = true;
+      if (writeAt && now - writeAt > 8000 && !firstGapAfterWrite) firstGapAfterWrite = now;
+      console.log(`[gap] reconnect window #${gaps}`);
+    }
+    last = now;
+    const s = (u as any).slot ? Number((u as any).slot.slot) : 0;
+    if (s) {
+      if (maxSlot && s < maxSlot - 1 && inGap) { rewinds++; console.log(`[replay] rewind ${maxSlot}->${s} (Δ${maxSlot - s})`); inGap = false; }
+      if (s > maxSlot) maxSlot = s;
+    }
+    if (u.transaction) txAt.push({ t: now, f: u.filters || [] });
+  }, () => {});
+
+  // write only once data is flowing (live connection) so it isn't lost mid-disconnect;
+  // a later reconnect then exercises persistence
+  for (let i = 0; i < 80 && txAt.length === 0; i++) await new Promise(r => setTimeout(r, 250));
+  await new Promise(r => setTimeout(r, 2000));
+  console.log('[write] USDC -> USDT');
+  await stream.write(req(USDT, 'usdt'));
+  writeAt = Date.now();
+
+  await new Promise(r => setTimeout(r, RUN_MS));
+  stream.cancel();
+
+  const set = (pred: (t: number) => boolean) => new Set(txAt.filter(e => pred(e.t)).flatMap(e => e.f));
+  const before = set(t => t < writeAt);
+  const after = set(t => t > writeAt + 8000);
+  const afterRecon = firstGapAfterWrite ? set(t => t > firstGapAfterWrite + 2000) : new Set<string>();
+
+  const checks: [string, boolean][] = [
+    ['USDC before write', before.has('usdc')],
+    ['write replaced USDC->USDT', !after.has('usdc') && after.has('usdt')],
+    ['reconnect observed', gaps > 0],
+    [REPLAY ? 'replay rewind after reconnect' : 'no rewind (replay off)', REPLAY ? rewinds > 0 : rewinds === 0],
+  ];
+  if (firstGapAfterWrite) checks.push(['write persisted after reconnect', afterRecon.has('usdt') && !afterRecon.has('usdc')]);
+
+  console.log(`\nreplay=${REPLAY} reconnects=${gaps} rewinds=${rewinds} maxSlot=${maxSlot}`);
+  let ok = true;
+  for (const [n, p] of checks) { console.log(`  ${p ? 'PASS' : 'FAIL'}  ${n}`); ok = ok && p; }
+  console.log(ok ? 'RESULT: PASS' : 'RESULT: FAIL');
+  process.exit(ok ? 0 : 1);
+}
+main().catch(e => { console.error(e); process.exit(2); });

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helius-laserstream"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 authors = ["Helius <support@helius.xyz>"]
 description = "Rust client for Helius LaserStream gRPC with robust reconnection and slot tracking"

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -218,9 +218,9 @@ pub fn subscribe(
                                             }
                                         }
                                         Err(status) => {
-                                            // Yield the error to consumer AND continue with reconnection
+                                            // Transient error: reconnect silently. Surfaced to the consumer
+                                            // only on terminal failure (max attempts) — see the Err arm below.
                                             warn!(error = %status, "Stream error, will reconnect after 5s delay");
-                                            yield Err(LaserstreamError::Status(status.clone()));
                                             break;
                                         }
                                     }

--- a/rust/test/subscription_replacement_persistence.rs
+++ b/rust/test/subscription_replacement_persistence.rs
@@ -139,6 +139,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let deadline = Instant::now() + Duration::from_secs(180);
 
+    // Reconnects aren't surfaced as errors anymore — detect one via a >4s data gap.
+    let gap_threshold = Duration::from_secs(4);
+    let mut last_update = Instant::now();
+    let mut in_gap = false;
+    let mut seen_first = false;
+
     while Instant::now() < deadline {
         // Early exit: Phase 3 has enough messages
         let p3_total = usdc_phase3.load(Ordering::Relaxed) + usdt_phase3.load(Ordering::Relaxed);
@@ -151,6 +157,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Some(result) = stream.next() => {
                 match result {
                     Ok(update) => {
+                        last_update = Instant::now();
+                        in_gap = false;
+                        seen_first = true;
                         if let Some(UpdateOneof::Transaction(_)) = &update.update_oneof {
                             let now = Instant::now();
                             let write_time = *write_completed_time.lock().await;
@@ -185,21 +194,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         }
                     }
                     Err(e) => {
-                        let recon_num = total_reconnects.fetch_add(1, Ordering::SeqCst) + 1;
-                        let write_time = *write_completed_time.lock().await;
-
-                        if write_time.is_some() {
-                            let n = reconnects_after_write.fetch_add(1, Ordering::SeqCst) + 1;
-                            reconnected_after_write.store(true, Ordering::SeqCst);
-                            *reconnect_after_write_time.lock().await = Some(Instant::now());
-                            eprintln!("[reconnect #{}] (after write, #{} post-write) {}", recon_num, n, e);
-                        } else {
-                            eprintln!("[reconnect #{}] (before write) {}", recon_num, e);
-                        }
+                        // Only fires on terminal failure (max attempts) now.
+                        eprintln!("[terminal error] stream yielded error: {}", e);
+                        break;
                     }
                 }
             }
-            _ = sleep(Duration::from_millis(100)) => {}
+            _ = sleep(Duration::from_millis(100)) => {
+                let now = Instant::now();
+                if seen_first && !in_gap && now.duration_since(last_update) > gap_threshold {
+                    in_gap = true;
+                    let gap_s = now.duration_since(last_update).as_secs_f64();
+                    let recon_num = total_reconnects.fetch_add(1, Ordering::SeqCst) + 1;
+                    let write_time = *write_completed_time.lock().await;
+                    if write_time.is_some() {
+                        let n = reconnects_after_write.fetch_add(1, Ordering::SeqCst) + 1;
+                        reconnected_after_write.store(true, Ordering::SeqCst);
+                        *reconnect_after_write_time.lock().await = Some(now);
+                        eprintln!("[reconnect #{}] (after write, #{} post-write) data gap {:.1}s", recon_num, n, gap_s);
+                    } else {
+                        eprintln!("[reconnect #{}] (before write) data gap {:.1}s", recon_num, gap_s);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
- **JS** — raise default `maxReconnectAttempts` from 120 to 240, for parity with Go/Rust
- **Rust** — `subscribe()` now reconnects silently, raising an error to the caller only after all retries are exhausted (matches Go/JS)
- **Rust** — release `helius-laserstream` v0.5.0 (from 0.4.1) for the contract change above
- **Tests** — add JS + Go harnesses exercising reconnect, replay, and `write()` persistence through the chaos proxy
