### PR TITLE
use Blocking callback on preprocessed stream to prevent dropped update

### DIFF
--- a/javascript/napi-src/stream.rs
+++ b/javascript/napi-src/stream.rs
@@ -744,7 +744,7 @@ impl StreamInner {
                             // Convert to bytes and send to JavaScript
                             match crate::subscribe_preprocessed_update_to_bytes(message) {
                                 Ok(bytes) => {
-                                    let _ = ts_callback.call(Ok(crate::SubscribePreprocessedUpdateBytes(bytes)), ThreadsafeFunctionCallMode::NonBlocking);
+                                    let _ = ts_callback.call(Ok(crate::SubscribePreprocessedUpdateBytes(bytes)), ThreadsafeFunctionCallMode::Blocking);
                                 }
                                 Err(e) => {
                                     eprintln!("Failed to encode preprocessed update: {}", e);


### PR DESCRIPTION
The JS NAPI preprocessed stream forwarded updates to JS using `NonBlocking`, which silently drops messages once the bounded 1000-deep callback queue fills under a slow consumer. Since the preprocessed path has no slot tracking or replay, a dropped update is lost forever. This switches it to `Blocking` so it matches the main `subscribe()` path — when the queue fills, the Rust task waits and back-pressure propagates to the server instead of discarding data.