### PR TITLE
Add Transaction Cuckoo Filter Support (Rust + JS)

### DIFF
--- a/javascript/Cargo.lock
+++ b/javascript/Cargo.lock
@@ -1262,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "laserstream-core-proto"
-version = "9.3.0"
+version = "9.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d31b6b2c1d727aef171a930b9a52d18df1deae9b4f816ca0f59ef94463ae5002"
+checksum = "3c1788d57b5764d7f69c73fafb6caea4c5c2ac395a03d70221c6acefba918e3a"
 dependencies = [
  "anyhow",
  "bincode",

--- a/javascript/Cargo.toml
+++ b/javascript/Cargo.toml
@@ -24,7 +24,7 @@ futures-channel = "0.3"
 parking_lot = "0.12"
 uuid = { version = "1", features = ["v4"] }
 laserstream-core-client = "9.0.2"
-laserstream-core-proto = { version = "9.3.0", default-features = false, features = ["tonic", "tonic-compression"] }
+laserstream-core-proto = { version = "9.4.0", default-features = false, features = ["tonic", "tonic-compression"] }
 prost = "0.14"
 bs58 = "0.5.0"
 fastrand = "2.0"

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -288,8 +288,26 @@ if (tracked.takeDirty()) {   // only re-send when the set actually changed
 }
 ```
 
+The same filter also works on **transaction** subscriptions, where it stands in for the
+`accountInclude` list (match any transaction that mentions a tracked account):
+
+```typescript
+const tracked = new CompressedAccountFilterSet(2_000_000);
+for (const pubkey of myTrackedPubkeys) {
+  tracked.insert(pubkey);
+}
+
+const request = { transactions: {}, commitment: CommitmentLevel.CONFIRMED };
+request.transactions['tracked_transactions'] = tracked.toTransactionFilter();
+
+const stream = await subscribe(config, request, (update) => {
+  // Re-check the touched accounts locally to drop the server's rare false positives.
+  console.log('transaction update:', update.transaction);
+});
+```
+
 Notes:
-- **Account subscriptions only.** Filters up to 32 MiB (~10M accounts).
+- **Account and transaction subscriptions.** Filters up to 32 MiB (~10M accounts).
 - `insert()` throws `TableFullError` if the filter saturates — rebuild with a larger capacity.
 - `contains()` is exact (backed by an internal `Set`); the cuckoo table is used only on the wire.
 

--- a/javascript/client.d.ts
+++ b/javascript/client.d.ts
@@ -112,6 +112,7 @@ export {
   DEFAULT_HASH_SEED,
   CuckooFilterProto,
   CuckooAccountFilter,
+  CuckooTransactionFilter,
   PubkeyInput,
 } from './cuckoo';
 
@@ -143,6 +144,11 @@ declare module 'laserstream-core-proto-js/generated' {
     interface ISubscribeRequestFilterTransactions {
       /** Helius ATA expansion control (proto field #30). */
       tokenAccounts?: (TokenAccountsFilterMode | string | null);
+      /**
+       * Compressed account (cuckoo) filter over `accountInclude` (proto field #31).
+       * Built client-side via {@link CompressedAccountFilterSet.toTransactionFilter}.
+       */
+      cuckooAccountInclude?: (import('./cuckoo').CuckooFilterProto | null);
     }
   }
 }

--- a/javascript/cuckoo.d.ts
+++ b/javascript/cuckoo.d.ts
@@ -30,6 +30,14 @@ export interface CuckooAccountFilter {
   cuckooAccountsFilter: CuckooFilterProto;
 }
 
+/** Transaction filter carrying only a cuckoo filter. */
+export interface CuckooTransactionFilter {
+  accountInclude: string[];
+  accountExclude: string[];
+  accountRequired: string[];
+  cuckooAccountInclude: CuckooFilterProto;
+}
+
 /** A pubkey accepted by the filter: base58 string, raw 32 bytes, or PublicKey-like. */
 export type PubkeyInput = string | Uint8Array | Buffer | number[] | { toBytes(): Uint8Array };
 
@@ -72,6 +80,8 @@ export declare class CompressedAccountFilterSet {
   toBytes(): Buffer;
   /** An account filter carrying only this cuckoo filter. */
   toAccountFilter(): CuckooAccountFilter;
+  /** A transaction filter carrying only this cuckoo filter. */
+  toTransactionFilter(): CuckooTransactionFilter;
   /** Insert into request.accounts[name] (replacing any existing entry) and clear the dirty flag. */
   insertIntoSubscribeRequest(request: SubscribeRequest, name: string): SubscribeRequest;
 }

--- a/javascript/cuckoo.js
+++ b/javascript/cuckoo.js
@@ -376,6 +376,16 @@ class CompressedAccountFilterSet {
     };
   }
 
+  /** A transaction filter carrying only this cuckoo filter (no accountInclude list). */
+  toTransactionFilter() {
+    return {
+      accountInclude: [],
+      accountExclude: [],
+      accountRequired: [],
+      cuckooAccountInclude: this.toProto(),
+    };
+  }
+
   /**
    * Insert this filter into `request.accounts[name]` (replacing any existing
    * entry, preserving others) and clear the dirty flag. Re-send the request on

--- a/javascript/examples/cuckoo-transaction-sub.ts
+++ b/javascript/examples/cuckoo-transaction-sub.ts
@@ -1,0 +1,49 @@
+import {
+  subscribe,
+  CommitmentLevel,
+  CompressedAccountFilterSet,
+  SubscribeUpdate,
+  LaserstreamConfig,
+} from '../client';
+
+async function main() {
+  const config: LaserstreamConfig = {
+    apiKey: 'your-api-key',
+    endpoint: 'your-endpoint',
+  };
+
+  // The accounts you want transactions to mention (accountInclude).
+  const addresses = [
+    'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', // USDC
+    'So11111111111111111111111111111111111111112',  // wSOL
+  ];
+
+  // Compact cuckoo filter instead of a full accountInclude list (size for your peak set).
+  const tracked = new CompressedAccountFilterSet(1_000_000);
+  for (const address of addresses) {
+    tracked.insert(address);
+  }
+
+  // Attach the filter to a transaction subscription (no explicit accountInclude needed).
+  const request: any = { transactions: {}, commitment: CommitmentLevel.PROCESSED };
+  request.transactions['tracked-transactions'] = tracked.toTransactionFilter();
+
+  const stream = await subscribe(
+    config,
+    request,
+    async (update: SubscribeUpdate) => {
+      // <1% false positives; re-check with tracked.contains(pubkey) if you need exactness.
+      console.log('transaction update:', update.transaction);
+    },
+    (error: Error) => {
+      console.error('Stream error:', error);
+    }
+  );
+
+  process.on('SIGINT', () => {
+    stream.cancel();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);

--- a/javascript/napi-src/client.rs
+++ b/javascript/napi-src/client.rs
@@ -172,6 +172,9 @@ pub struct JsTransactionFilter {
     // Helius ATA expansion control (proto field #30): "none" | "balanceChanged" | "all".
     #[serde(alias = "tokenAccounts")]
     pub token_accounts: Option<String>,
+    // Cuckoo filter over accountInclude (proto field #31), built client-side.
+    #[serde(alias = "cuckooAccountInclude")]
+    pub cuckoo_account_include: Option<JsCuckooFilter>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -408,6 +411,22 @@ impl ClientInner {
 
                 yellowstone_filter.token_accounts = parse_token_accounts_mode(filter.token_accounts)
                     .map_err(Error::from_reason)?;
+
+                // Handle compressed account (cuckoo) filter — pass through bytes built client-side.
+                if let Some(cuckoo) = filter.cuckoo_account_include {
+                    let data = general_purpose::STANDARD.decode(&cuckoo.data)
+                        .map_err(|e| Error::new(Status::InvalidArg, format!("Invalid base64 cuckoo data: {}", e)))?;
+                    let hash_seed = cuckoo.hash_seed.parse::<u64>()
+                        .map_err(|e| Error::new(Status::InvalidArg, format!("Invalid cuckoo hash_seed: {}", e)))?;
+                    yellowstone_filter.cuckoo_account_include = Some(CuckooFilter {
+                        data,
+                        bucket_count: cuckoo.bucket_count,
+                        entries_per_bucket: cuckoo.entries_per_bucket,
+                        fingerprint_bits: cuckoo.fingerprint_bits,
+                        hash_seed,
+                        hash_algorithm: cuckoo.hash_algorithm,
+                    });
+                }
 
                 transactions_map.insert(key, yellowstone_filter);
             }

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -21,6 +21,7 @@
     "build:musl": "cargo zigbuild --release --target $CARGO_BUILD_TARGET && napi build --platform --release --skip-build",
     "example:account-sub": "ts-node examples/account-sub.ts",
     "example:cuckoo-account-sub": "ts-node examples/cuckoo-account-sub.ts",
+    "example:cuckoo-transaction-sub": "ts-node examples/cuckoo-transaction-sub.ts",
     "example:accounts-data-slice-sub": "ts-node examples/accounts-data-slice-sub.ts",
     "example:slot-sub": "ts-node examples/slot-sub.ts",
     "example:transaction-sub": "ts-node examples/transaction-sub.ts",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -974,7 +974,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helius-laserstream"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-stream",
  "bs58",
@@ -1416,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "laserstream-core-proto"
-version = "9.3.0"
+version = "9.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d31b6b2c1d727aef171a930b9a52d18df1deae9b4f816ca0f59ef94463ae5002"
+checksum = "3c1788d57b5764d7f69c73fafb6caea4c5c2ac395a03d70221c6acefba918e3a"
 dependencies = [
  "anyhow",
  "bincode",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-laserstream-core-proto = { version = "9.3.0", default-features = false, features = ["tonic", "tonic-compression"] }
+laserstream-core-proto = { version = "9.4.0", default-features = false, features = ["tonic", "tonic-compression"] }
 laserstream-core-client = "9.0.2"
 tonic = { version = "0.12.1", features = ["transport", "tls", "zstd", "gzip"] }
 prost = "0.12"
@@ -54,6 +54,11 @@ dotenv = "0.15"
 [[example]]
 name = "cuckoo_account_filter"
 path = "examples/cuckoo_account_filter.rs"
+required-features = ["cuckoo"]
+
+[[example]]
+name = "cuckoo_transaction_filter"
+path = "examples/cuckoo_transaction_filter.rs"
 required-features = ["cuckoo"]
 
 [build-dependencies]

--- a/rust/README.md
+++ b/rust/README.md
@@ -342,8 +342,12 @@ if tracked.take_dirty() {
 }
 ```
 
-Account subscriptions only; filters up to 32 MiB (~10M accounts). See
-`examples/cuckoo_account_filter.rs`.
+The same filter also works on **transaction subscriptions**: set its `to_proto()`
+on a `SubscribeRequestFilterTransactions.cuckoo_account_include` (OR-combined with
+the explicit `account_include` list) and add it to `request.transactions`. See
+`examples/cuckoo_transaction_filter.rs`.
+
+Filters up to 32 MiB (~10M accounts). See `examples/cuckoo_account_filter.rs`.
 
 ## Compression Examples
 

--- a/rust/examples/cuckoo_transaction_filter.rs
+++ b/rust/examples/cuckoo_transaction_filter.rs
@@ -1,0 +1,96 @@
+//! Transaction cuckoo filter example: track accounts via a compact filter instead
+//! of an explicit `account_include` list; re-check matches locally (<1% FPs).
+//!
+//!   LASERSTREAM_ENDPOINT=... LASERSTREAM_API_KEY=... cargo run --example cuckoo_transaction_filter
+
+use {
+    futures::StreamExt,
+    helius_laserstream::{
+        cuckoo::{CompressedAccountFilterSet, Pubkey},
+        grpc::{subscribe_update::UpdateOneof, SubscribeRequest, SubscribeRequestFilterTransactions},
+        subscribe, LaserstreamConfig,
+    },
+    std::str::FromStr,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenv::dotenv();
+    let endpoint = std::env::var("LASERSTREAM_ENDPOINT")?;
+    let api_key = std::env::var("LASERSTREAM_API_KEY")?;
+
+    // The exact set of accounts we want transactions for.
+    let tracked: Vec<Pubkey> = [
+        "So11111111111111111111111111111111111111112", // Wrapped SOL
+        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", // USDC
+        "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", // USDT
+    ]
+    .iter()
+    .map(|s| Pubkey::from_str(s).unwrap())
+    .collect();
+
+    // Build the cuckoo filter. Size it for your peak tracked-set size.
+    let mut set = CompressedAccountFilterSet::with_capacity(1_000_000)?;
+    for pk in &tracked {
+        set.insert(*pk)?;
+    }
+    println!(
+        "Tracking {} accounts via cuckoo filter ({} bytes on the wire)",
+        set.len(),
+        set.to_proto().data.len()
+    );
+
+    // Rides on the transaction filter's `cuckoo_account_include` (no explicit list sent).
+    let mut request = SubscribeRequest::default();
+    request.transactions.insert(
+        "tracked_accounts".to_string(),
+        SubscribeRequestFilterTransactions {
+            vote: Some(false),
+            failed: Some(false),
+            cuckoo_account_include: Some(set.to_proto()),
+            ..Default::default()
+        },
+    );
+
+    let config = LaserstreamConfig::new(endpoint, api_key);
+
+    let (stream, _handle) = subscribe(config, request);
+    tokio::pin!(stream);
+    while let Some(message) = stream.next().await {
+        match message {
+            Ok(update) => {
+                if let Some(UpdateOneof::Transaction(tx_update)) = update.update_oneof {
+                    if let Some(info) = tx_update.transaction {
+                        // Re-check locally: keep only txns that really touch a tracked
+                        // account (drops server-side false positives).
+                        let touches_tracked = info
+                            .transaction
+                            .as_ref()
+                            .and_then(|tx| tx.message.as_ref())
+                            .map(|msg| {
+                                msg.account_keys.iter().any(|key| {
+                                    Pubkey::try_from(key.as_slice())
+                                        .map(|pk| set.contains(pk))
+                                        .unwrap_or(false)
+                                })
+                            })
+                            .unwrap_or(false);
+
+                        if touches_tracked {
+                            println!(
+                                "tracked txn: {} (slot {})",
+                                bs58::encode(&info.signature).into_string(),
+                                tx_update.slot
+                            );
+                        } else {
+                            println!("(false positive, ignored) slot {}", tx_update.slot);
+                        }
+                    }
+                }
+            }
+            Err(e) => eprintln!("stream error: {e}"),
+        }
+    }
+
+    Ok(())
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -36,6 +36,10 @@ pub use laserstream_core_proto::solana;
 ///     // handle.write(req).await
 /// }
 /// ```
+///
+/// Also works on transaction subscriptions: put `set.to_proto()` on
+/// `SubscribeRequestFilterTransactions.cuckoo_account_include` (see the
+/// `cuckoo_transaction_filter` example).
 #[cfg(feature = "cuckoo")]
 pub mod cuckoo {
     pub use laserstream_core_proto::cuckoo::{


### PR DESCRIPTION
Adds optional **transaction** cuckoo filtering to the Rust and JS SDKs, mirroring the account cuckoo feature from #90.

A client compresses a large `account_include` set into a compact cuckoo filter and attaches it to a transaction subscription via `cuckoo_account_include` (proto field 31, same `CuckooFilter` message as the account field). The server OR-combines it with the explicit `account_include`; `account_exclude` / `account_required` are unaffected.

## Changes
- Bump `laserstream-core-proto` 9.3.0 → **9.4.0** (adds field 31) in both SDKs.
- **Rust**: new `cuckoo_transaction_filter` example; `cuckoo` module doc + README note. The SDK re-exports the proto types directly, so users set `cuckoo_account_include: Some(set.to_proto())` on `SubscribeRequestFilterTransactions`.
- **JS**: `cuckoo.js` `toTransactionFilter()`; `cuckoo.d.ts` `CuckooTransactionFilter`; `client.d.ts` `cuckooAccountInclude` on `ISubscribeRequestFilterTransactions`; napi passthrough to `cuckoo_account_include`; example + README.

The existing `CompressedAccountFilterSet` builder is reused unchanged (`to_proto` / `toProto`) — the wire `CuckooFilter` bytes are identical to the account path.

## Notes
- No SDK version bump (main is unreleased).
- Go SDK is out of scope.
- Builds verified against the published `laserstream-core-proto` 9.4.0: Rust lib + both examples, and the JS napi binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)