### PR TITLE
Release JS helius-laserstream 0.7.0

### DIFF
--- a/javascript/Cargo.lock
+++ b/javascript/Cargo.lock
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "laserstream-napi"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "base64 0.21.7",
  "bs58",

--- a/javascript/Cargo.toml
+++ b/javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laserstream-napi"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 
 [lib]

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helius-laserstream",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "High-performance Laserstream gRPC client with automatic reconnection",
   "main": "client.js",
   "types": "client.d.ts",
@@ -92,12 +92,12 @@
     }
   },
   "optionalDependencies": {
-    "helius-laserstream-darwin-arm64": "0.6.1",
-    "helius-laserstream-darwin-x64": "0.6.1",
-    "helius-laserstream-linux-arm64-gnu": "0.6.1",
-    "helius-laserstream-linux-arm64-musl": "0.6.1",
-    "helius-laserstream-linux-x64-gnu": "0.6.1",
-    "helius-laserstream-linux-x64-musl": "0.6.1"
+    "helius-laserstream-darwin-arm64": "0.7.0",
+    "helius-laserstream-darwin-x64": "0.7.0",
+    "helius-laserstream-linux-arm64-gnu": "0.7.0",
+    "helius-laserstream-linux-arm64-musl": "0.7.0",
+    "helius-laserstream-linux-x64-gnu": "0.7.0",
+    "helius-laserstream-linux-x64-musl": "0.7.0"
   },
   "dependencies": {
     "laserstream-core-proto-js": "^9.0.2",


### PR DESCRIPTION
Bumps the JS SDK **0.6.1 → 0.7.0** to publish transaction cuckoo support (#102) to npm.

0.6.1 is already published, so a new version is required. Minor bump (new feature: `cuckoo_account_include` on transaction subscriptions), matching the account-cuckoo release convention (0.3.2 → 0.4.0).

Touches version fields only: `package.json` (version + 6 platform optionalDependencies), napi `Cargo.toml` + `Cargo.lock`.

**To publish after merge:** tag `v0.7.0` on the merge commit and publish a GitHub release from it — the `ci.yml` publish job fires on `release: published` and reads the version from `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)