### PR TITLE
CI: Build aarch64-Linux on Native ARM Runners (Kill QEMU)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             docker: gnu
             build: npm run build -- --target x86_64-unknown-linux-gnu
-          - host: ubuntu-latest
+          - host: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             docker: gnu
             build: npm run build -- --target aarch64-unknown-linux-gnu
@@ -41,7 +41,7 @@ jobs:
             target: x86_64-unknown-linux-musl
             docker: musl
             build: npm run build -- --target x86_64-unknown-linux-musl
-          - host: ubuntu-latest
+          - host: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             docker: musl
             build: npm run build -- --target aarch64-unknown-linux-musl
@@ -82,8 +82,11 @@ jobs:
           restore-keys: |
             ${{ matrix.settings.target }}-cargo-${{ matrix.settings.host }}-
             ${{ matrix.settings.target }}-cargo-
+      # QEMU is only needed when the runner arch differs from the container arch
+      # (x86 host building an arm64 container). Native aarch64 runners
+      # (ubuntu-24.04-arm) run the arm64 container directly — no emulation.
       - name: Set up QEMU for cross-compilation
-        if: matrix.settings.docker
+        if: matrix.settings.docker && matrix.settings.host == 'ubuntu-latest'
         uses: docker/setup-qemu-action@v3
       - name: Build in Docker (musl)
         if: matrix.settings.docker == 'musl'


### PR DESCRIPTION
## Summary

Move the two `aarch64-unknown-linux-{gnu,musl}` release builds off QEMU-emulated x86 runners onto native ARM runners (`ubuntu-24.04-arm`), so the crypto-heavy dep tree compiles in minutes instead of 60min+.

## Why

The v0.8.0 release exposed this. The aarch64-linux legs build inside a `linux/arm64` docker container on an x86 `ubuntu-latest` runner via **QEMU emulation**. That was tolerable when the dep tree was light (~5-8min on v0.7.0), but v0.8.0 bumped `laserstream-core-proto`/`-client` **9.x → 11.0.0**, which pulled Solana **3.x → 4.x** and the **ed25519-dalek / curve25519-dalek / RustCrypto (der/pkcs8/spki)** crypto stack. Those crates do heavy curve/bignum const-eval that is pathologically slow under emulation — the aarch64 legs jumped to **60min+** (still running at 70min+ on the v0.8.0 release as of this PR).

Root cause confirmed by diffing the v0.7.0 vs v0.8.0 lockfiles: crate count is flat (~402), but the content shifted to the Solana-4.x crypto crates, and `bindgen`/`clang-sys` were replaced by pure-Rust crypto (more Rust to compile under QEMU).

## Changes

- `aarch64-unknown-linux-gnu` and `aarch64-unknown-linux-musl` matrix legs: `host: ubuntu-latest` → `host: ubuntu-24.04-arm` (GitHub native ARM64 runners).
- The existing `docker run` build containers (`debian:bullseye` for gnu = glibc 2.31 floor; `rust:alpine` for musl) are unchanged and now run **natively** (arm64 container on arm64 host = no emulation).
- QEMU setup step gated to x86 hosts only (`matrix.settings.host == 'ubuntu-latest'`), so the native ARM legs never register emulators.

## Compatibility

- **glibc / musl floors unchanged** — same containers (bullseye glibc 2.31, Alpine musl), so the published `.node` binaries keep the same minimum-runtime requirements. Only the *build host* changed, not the *build target/sysroot*.
- x86 gnu/musl and both darwin legs are untouched.

## Testing without releasing

The `publish` job is gated `if: github.event_name == 'release'`, but the `build` matrix runs on `pull_request`. **This PR's own CI builds all 6 platforms — including the two native-ARM legs — and publishes nothing.** That is the test: compare the aarch64-linux build times on `ubuntu-24.04-arm` here vs the ~60min emulated builds. First run is a cold cache (key includes host, which changed) so not instant, but native-cold is far faster than emulated-cold, and warm thereafter.

## Follow-up (optional)

Add sccache (`mozilla-actions/sccache-action` + `RUSTC_WRAPPER`) to cache compiler outputs across Cargo.lock-hash changes, so even cold (dep-changing) releases are fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
