### PR TITLE
CI: retry npm view in publication verify step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,17 +346,22 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           echo "🔍 Verifying publication of version $VERSION"
-          
-          # Wait a moment for NPM to propagate
-          sleep 10
-          
-          # Check main package
-          if ! npm view helius-laserstream@$VERSION version > /dev/null 2>&1; then
-            echo "❌ Error: Main package helius-laserstream@$VERSION not found on NPM"
-            exit 1
-          fi
-          
-          # Check platform packages
+
+          # npm reads are eventually consistent; retry briefly before failing
+          verify_package() {
+            for i in 1 2 3 4 5 6; do
+              if npm view "$1@$VERSION" version > /dev/null 2>&1; then
+                echo "✅ Verified: $1@$VERSION"
+                return 0
+              fi
+              sleep 10
+            done
+            echo "❌ Error: Package $1@$VERSION not found on NPM"
+            return 1
+          }
+
+          verify_package helius-laserstream
+
           PLATFORM_PACKAGES=(
             "helius-laserstream-darwin-x64"
             "helius-laserstream-darwin-arm64"
@@ -365,13 +370,9 @@ jobs:
             "helius-laserstream-linux-x64-musl"
             "helius-laserstream-linux-arm64-musl"
           )
-          
+
           for package in "${PLATFORM_PACKAGES[@]}"; do
-            if ! npm view "$package@$VERSION" version > /dev/null 2>&1; then
-              echo "❌ Error: Platform package $package@$VERSION not found on NPM"
-              exit 1
-            fi
-            echo "✅ Verified: $package@$VERSION"
+            verify_package "$package"
           done
           
           echo "🎉 All packages successfully published and verified!" 


### PR DESCRIPTION
## Summary
The v0.8.2 release publish succeeded, but the **Verify publication** step failed ([run](https://github.com/helius-labs/laserstream-sdk/actions/runs/31528932916)): it slept a fixed 10 seconds and then did a single `npm view`, which hit an npm read replica that hadn't propagated the just-published version yet. npm registry reads are eventually consistent, so a single check that soon after publish is flaky by design.

## Change
Replace the fixed `sleep 10` + one-shot checks with a small `verify_package` retry helper:
- checks each package immediately (no upfront sleep — normal case passes instantly)
- on a miss, retries every 10s up to 6 attempts (~60s max per package) before failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)