### PR TITLE
feat(go): tokenAccounts (ATA) transaction filter

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -145,6 +145,37 @@ req := &laserstream.SubscribeRequest{
 }
 ```
 
+#### tokenAccounts (ATA) Expansion
+
+Set `TokenAccounts` on a transaction filter to also match transactions that
+touch an **Associated Token Account (ATA)** owned by one of the
+`AccountInclude` wallets, not just transactions naming the wallet directly.
+Modes:
+
+- unset (`nil`) — no expansion (default).
+- `TokenAccountExpansionControlFlag_BALANCE_CHANGED` — also match txs touching
+  an ATA owned by an `AccountInclude` wallet whose token balance changed.
+- `TokenAccountExpansionControlFlag_ALL` — match any tx touching an ATA owned
+  by an `AccountInclude` wallet.
+
+```go
+vote := false
+failed := false
+req := &laserstream.SubscribeRequest{
+    Transactions: map[string]*laserstream.SubscribeRequestFilterTransactions{
+        "wallet-and-atas": {
+            AccountInclude: []string{"vines1vzrYbzLMRdu58ou5XTby4qAqVRLmqo36NKPTg"},
+            Vote:           &vote,
+            Failed:         &failed,
+            TokenAccounts:  laserstream.TokenAccountExpansionControlFlag_BALANCE_CHANGED.Enum(),
+        },
+    },
+    Commitment: &commitmentLevel,
+}
+```
+
+See [`examples/token-accounts-sub.go`](./examples/token-accounts-sub.go).
+
 ### Block Subscriptions
 ```go
 includeTransactions := true

--- a/go/examples/token-accounts-sub.go
+++ b/go/examples/token-accounts-sub.go
@@ -1,0 +1,88 @@
+// tokenAccounts (ATA) transaction filter.
+//
+// Subscribe to transactions touching a wallet *and* its Associated Token
+// Accounts (ATAs) by setting the `TokenAccounts` field on a transaction
+// filter alongside `AccountInclude`. Modes:
+//
+//   - unset (nil)                                        — no expansion (default).
+//   - TokenAccountExpansionControlFlag_BALANCE_CHANGED   — also match txs touching
+//     an ATA owned by an AccountInclude wallet whose token balance changed.
+//   - TokenAccountExpansionControlFlag_ALL               — match any tx touching
+//     an ATA owned by an AccountInclude wallet.
+//
+// Run with: go run examples/token-accounts-sub.go
+package main
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	laserstream "github.com/helius-labs/laserstream-sdk/go"
+
+	"github.com/joho/godotenv"
+)
+
+func main() {
+	log.SetFlags(0)
+
+	godotenv.Load("../.env")
+
+	endpoint := os.Getenv("LASERSTREAM_ENDPOINT")
+	apiKey := os.Getenv("LASERSTREAM_API_KEY")
+	if endpoint == "" || apiKey == "" {
+		log.Fatal("LASERSTREAM_ENDPOINT and LASERSTREAM_API_KEY must be set")
+	}
+
+	// Example wallet to watch; replace with your own.
+	wallet := os.Getenv("WATCH_WALLET")
+	if wallet == "" {
+		wallet = "vines1vzrYbzLMRdu58ou5XTby4qAqVRLmqo36NKPTg"
+	}
+
+	clientConfig := laserstream.LaserstreamConfig{
+		Endpoint: endpoint,
+		APIKey:   apiKey,
+	}
+
+	commitmentLevel := laserstream.CommitmentLevel_CONFIRMED
+	vote := false
+	failed := false
+	subscriptionRequest := &laserstream.SubscribeRequest{
+		Transactions: map[string]*laserstream.SubscribeRequestFilterTransactions{
+			"wallet-and-atas": {
+				AccountInclude: []string{wallet},
+				Vote:           &vote,
+				Failed:         &failed,
+				// Expand the subscription to ATAs owned by the watched wallet
+				// whose token balance changed in the transaction.
+				TokenAccounts: laserstream.TokenAccountExpansionControlFlag_BALANCE_CHANGED.Enum(),
+			},
+		},
+		Commitment: &commitmentLevel,
+	}
+
+	client := laserstream.NewClient(clientConfig)
+
+	dataCallback := func(data *laserstream.SubscribeUpdate) {
+		if tx := data.GetTransaction(); tx != nil {
+			log.Printf("slot=%d sig=%x", tx.Slot, tx.GetTransaction().GetSignature())
+		}
+	}
+
+	errorCallback := func(err error) {
+		log.Printf("Error: %v", err)
+	}
+
+	err := client.Subscribe(subscriptionRequest, dataCallback, errorCallback)
+	if err != nil {
+		log.Fatalf("Failed to subscribe: %v", err)
+	}
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	<-sigChan
+
+	client.Unsubscribe()
+}

--- a/go/laserstream.go
+++ b/go/laserstream.go
@@ -33,7 +33,7 @@ const (
 // SDK metadata constants
 const (
 	SDKName    = "laserstream-go"
-	SDKVersion = "0.1.4"
+	SDKVersion = "0.2.0"
 )
 
 // Commitment levels
@@ -766,6 +766,18 @@ const (
 
 // CommitmentLevel type
 type CommitmentLevel = pb.CommitmentLevel
+
+// Helius extension: ATA / token-account expansion control for the
+// `TokenAccounts` field on transaction / transactionsStatus filters.
+type TokenAccountExpansionControlFlag = pb.TokenAccountExpansionControlFlag
+
+const (
+	// Match an owner if it owns a pre OR post token balance on the tx.
+	TokenAccountExpansionControlFlag_ALL = pb.TokenAccountExpansionControlFlag_ALL
+	// Match an owner whose token balance changed in amount or whose token
+	// account was closed.
+	TokenAccountExpansionControlFlag_BALANCE_CHANGED = pb.TokenAccountExpansionControlFlag_BALANCE_CHANGED
+)
 
 // Filter types for different subscription types
 type (

--- a/go/proto/geyser.pb.go
+++ b/go/proto/geyser.pb.go
@@ -132,6 +132,56 @@ func (SlotStatus) EnumDescriptor() ([]byte, []int) {
 	return file_geyser_proto_rawDescGZIP(), []int{1}
 }
 
+// Helius extension: discriminator for `SubscribeRequestFilterTransactions.token_accounts`.
+type TokenAccountExpansionControlFlag int32
+
+const (
+	// Match an owner if it owns a pre OR post token balance on the tx.
+	TokenAccountExpansionControlFlag_ALL TokenAccountExpansionControlFlag = 0
+	// Match an owner whose token balance changed in amount (per
+	// `account_index`) or whose token account was closed.
+	TokenAccountExpansionControlFlag_BALANCE_CHANGED TokenAccountExpansionControlFlag = 1
+)
+
+// Enum value maps for TokenAccountExpansionControlFlag.
+var (
+	TokenAccountExpansionControlFlag_name = map[int32]string{
+		0: "ALL",
+		1: "BALANCE_CHANGED",
+	}
+	TokenAccountExpansionControlFlag_value = map[string]int32{
+		"ALL":             0,
+		"BALANCE_CHANGED": 1,
+	}
+)
+
+func (x TokenAccountExpansionControlFlag) Enum() *TokenAccountExpansionControlFlag {
+	p := new(TokenAccountExpansionControlFlag)
+	*p = x
+	return p
+}
+
+func (x TokenAccountExpansionControlFlag) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (TokenAccountExpansionControlFlag) Descriptor() protoreflect.EnumDescriptor {
+	return file_geyser_proto_enumTypes[2].Descriptor()
+}
+
+func (TokenAccountExpansionControlFlag) Type() protoreflect.EnumType {
+	return &file_geyser_proto_enumTypes[2]
+}
+
+func (x TokenAccountExpansionControlFlag) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use TokenAccountExpansionControlFlag.Descriptor instead.
+func (TokenAccountExpansionControlFlag) EnumDescriptor() ([]byte, []int) {
+	return file_geyser_proto_rawDescGZIP(), []int{2}
+}
+
 // Subscriptions to Preprocessed transactions
 type SubscribePreprocessedRequest struct {
 	state         protoimpl.MessageState                                     `protogen:"open.v1"`
@@ -1083,8 +1133,13 @@ type SubscribeRequestFilterTransactions struct {
 	AccountInclude  []string               `protobuf:"bytes,3,rep,name=account_include,json=accountInclude,proto3" json:"account_include,omitempty"`
 	AccountExclude  []string               `protobuf:"bytes,4,rep,name=account_exclude,json=accountExclude,proto3" json:"account_exclude,omitempty"`
 	AccountRequired []string               `protobuf:"bytes,6,rep,name=account_required,json=accountRequired,proto3" json:"account_required,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// Helius extension: ATA / token-account expansion control. When set,
+	// account_include / account_exclude / account_required also match
+	// against owners of pre/post token balances on each transaction.
+	// Absent = no expansion.
+	TokenAccounts *TokenAccountExpansionControlFlag `protobuf:"varint,30,opt,name=token_accounts,json=tokenAccounts,proto3,enum=geyser.TokenAccountExpansionControlFlag,oneof" json:"token_accounts,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SubscribeRequestFilterTransactions) Reset() {
@@ -1157,6 +1212,13 @@ func (x *SubscribeRequestFilterTransactions) GetAccountRequired() []string {
 		return x.AccountRequired
 	}
 	return nil
+}
+
+func (x *SubscribeRequestFilterTransactions) GetTokenAccounts() TokenAccountExpansionControlFlag {
+	if x != nil && x.TokenAccounts != nil {
+		return *x.TokenAccounts
+	}
+	return TokenAccountExpansionControlFlag_ALL
 }
 
 type SubscribeRequestFilterBlocks struct {
@@ -3232,18 +3294,20 @@ const file_geyser_proto_rawDesc = "" +
 	"\x14filter_by_commitment\x18\x01 \x01(\bH\x00R\x12filterByCommitment\x88\x01\x01\x120\n" +
 	"\x11interslot_updates\x18\x02 \x01(\bH\x01R\x10interslotUpdates\x88\x01\x01B\x17\n" +
 	"\x15_filter_by_commitmentB\x14\n" +
-	"\x12_interslot_updates\"\x9c\x02\n" +
+	"\x12_interslot_updates\"\x85\x03\n" +
 	"\"SubscribeRequestFilterTransactions\x12\x17\n" +
 	"\x04vote\x18\x01 \x01(\bH\x00R\x04vote\x88\x01\x01\x12\x1b\n" +
 	"\x06failed\x18\x02 \x01(\bH\x01R\x06failed\x88\x01\x01\x12!\n" +
 	"\tsignature\x18\x05 \x01(\tH\x02R\tsignature\x88\x01\x01\x12'\n" +
 	"\x0faccount_include\x18\x03 \x03(\tR\x0eaccountInclude\x12'\n" +
 	"\x0faccount_exclude\x18\x04 \x03(\tR\x0eaccountExclude\x12)\n" +
-	"\x10account_required\x18\x06 \x03(\tR\x0faccountRequiredB\a\n" +
+	"\x10account_required\x18\x06 \x03(\tR\x0faccountRequired\x12T\n" +
+	"\x0etoken_accounts\x18\x1e \x01(\x0e2(.geyser.TokenAccountExpansionControlFlagH\x03R\rtokenAccounts\x88\x01\x01B\a\n" +
 	"\x05_voteB\t\n" +
 	"\a_failedB\f\n" +
 	"\n" +
-	"_signature\"\x9f\x02\n" +
+	"_signatureB\x11\n" +
+	"\x0f_token_accounts\"\x9f\x02\n" +
 	"\x1cSubscribeRequestFilterBlocks\x12'\n" +
 	"\x0faccount_include\x18\x01 \x03(\tR\x0eaccountInclude\x126\n" +
 	"\x14include_transactions\x18\x02 \x01(\bH\x00R\x13includeTransactions\x88\x01\x01\x12.\n" +
@@ -3413,7 +3477,10 @@ const file_geyser_proto_rawDesc = "" +
 	"\x19SLOT_FIRST_SHRED_RECEIVED\x10\x03\x12\x12\n" +
 	"\x0eSLOT_COMPLETED\x10\x04\x12\x15\n" +
 	"\x11SLOT_CREATED_BANK\x10\x05\x12\r\n" +
-	"\tSLOT_DEAD\x10\x062\xdf\x05\n" +
+	"\tSLOT_DEAD\x10\x06*@\n" +
+	" TokenAccountExpansionControlFlag\x12\a\n" +
+	"\x03ALL\x10\x00\x12\x13\n" +
+	"\x0fBALANCE_CHANGED\x10\x012\xdf\x05\n" +
 	"\x06Geyser\x12D\n" +
 	"\tSubscribe\x12\x18.geyser.SubscribeRequest\x1a\x17.geyser.SubscribeUpdate\"\x00(\x010\x01\x12h\n" +
 	"\x15SubscribePreprocessed\x12$.geyser.SubscribePreprocessedRequest\x1a#.geyser.SubscribePreprocessedUpdate\"\x00(\x010\x01\x12`\n" +
@@ -3438,154 +3505,156 @@ func file_geyser_proto_rawDescGZIP() []byte {
 	return file_geyser_proto_rawDescData
 }
 
-var file_geyser_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_geyser_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
 var file_geyser_proto_msgTypes = make([]protoimpl.MessageInfo, 52)
 var file_geyser_proto_goTypes = []any{
 	(CommitmentLevel)(0),                                   // 0: geyser.CommitmentLevel
 	(SlotStatus)(0),                                        // 1: geyser.SlotStatus
-	(*SubscribePreprocessedRequest)(nil),                   // 2: geyser.SubscribePreprocessedRequest
-	(*SubscribePreprocessedRequestFilterTransactions)(nil), // 3: geyser.SubscribePreprocessedRequestFilterTransactions
-	(*SubscribePreprocessedUpdate)(nil),                    // 4: geyser.SubscribePreprocessedUpdate
-	(*SubscribePreprocessedTransaction)(nil),               // 5: geyser.SubscribePreprocessedTransaction
-	(*SubscribePreprocessedTransactionInfo)(nil),           // 6: geyser.SubscribePreprocessedTransactionInfo
-	(*SubscribeRequest)(nil),                               // 7: geyser.SubscribeRequest
-	(*SubscribeRequestFilterAccounts)(nil),                 // 8: geyser.SubscribeRequestFilterAccounts
-	(*SubscribeRequestFilterAccountsFilter)(nil),           // 9: geyser.SubscribeRequestFilterAccountsFilter
-	(*SubscribeRequestFilterAccountsFilterMemcmp)(nil),     // 10: geyser.SubscribeRequestFilterAccountsFilterMemcmp
-	(*SubscribeRequestFilterAccountsFilterLamports)(nil),   // 11: geyser.SubscribeRequestFilterAccountsFilterLamports
-	(*SubscribeRequestFilterSlots)(nil),                    // 12: geyser.SubscribeRequestFilterSlots
-	(*SubscribeRequestFilterTransactions)(nil),             // 13: geyser.SubscribeRequestFilterTransactions
-	(*SubscribeRequestFilterBlocks)(nil),                   // 14: geyser.SubscribeRequestFilterBlocks
-	(*SubscribeRequestFilterBlocksMeta)(nil),               // 15: geyser.SubscribeRequestFilterBlocksMeta
-	(*SubscribeRequestFilterEntry)(nil),                    // 16: geyser.SubscribeRequestFilterEntry
-	(*SubscribeRequestAccountsDataSlice)(nil),              // 17: geyser.SubscribeRequestAccountsDataSlice
-	(*SubscribeRequestPing)(nil),                           // 18: geyser.SubscribeRequestPing
-	(*SubscribeUpdate)(nil),                                // 19: geyser.SubscribeUpdate
-	(*SubscribeUpdateBatch)(nil),                           // 20: geyser.SubscribeUpdateBatch
-	(*SubscribeUpdateAccount)(nil),                         // 21: geyser.SubscribeUpdateAccount
-	(*SubscribeUpdateAccountInfo)(nil),                     // 22: geyser.SubscribeUpdateAccountInfo
-	(*SubscribeUpdateSlot)(nil),                            // 23: geyser.SubscribeUpdateSlot
-	(*SubscribeUpdateTransaction)(nil),                     // 24: geyser.SubscribeUpdateTransaction
-	(*SubscribeUpdateTransactionInfo)(nil),                 // 25: geyser.SubscribeUpdateTransactionInfo
-	(*SubscribeUpdateTransactionStatus)(nil),               // 26: geyser.SubscribeUpdateTransactionStatus
-	(*SubscribeUpdateBlock)(nil),                           // 27: geyser.SubscribeUpdateBlock
-	(*SubscribeUpdateBlockMeta)(nil),                       // 28: geyser.SubscribeUpdateBlockMeta
-	(*SubscribeUpdateEntry)(nil),                           // 29: geyser.SubscribeUpdateEntry
-	(*SubscribeUpdatePing)(nil),                            // 30: geyser.SubscribeUpdatePing
-	(*SubscribeUpdatePong)(nil),                            // 31: geyser.SubscribeUpdatePong
-	(*SubscribeReplayInfoRequest)(nil),                     // 32: geyser.SubscribeReplayInfoRequest
-	(*SubscribeReplayInfoResponse)(nil),                    // 33: geyser.SubscribeReplayInfoResponse
-	(*PingRequest)(nil),                                    // 34: geyser.PingRequest
-	(*PongResponse)(nil),                                   // 35: geyser.PongResponse
-	(*GetLatestBlockhashRequest)(nil),                      // 36: geyser.GetLatestBlockhashRequest
-	(*GetLatestBlockhashResponse)(nil),                     // 37: geyser.GetLatestBlockhashResponse
-	(*GetBlockHeightRequest)(nil),                          // 38: geyser.GetBlockHeightRequest
-	(*GetBlockHeightResponse)(nil),                         // 39: geyser.GetBlockHeightResponse
-	(*GetSlotRequest)(nil),                                 // 40: geyser.GetSlotRequest
-	(*GetSlotResponse)(nil),                                // 41: geyser.GetSlotResponse
-	(*GetVersionRequest)(nil),                              // 42: geyser.GetVersionRequest
-	(*GetVersionResponse)(nil),                             // 43: geyser.GetVersionResponse
-	(*IsBlockhashValidRequest)(nil),                        // 44: geyser.IsBlockhashValidRequest
-	(*IsBlockhashValidResponse)(nil),                       // 45: geyser.IsBlockhashValidResponse
-	nil,                                                    // 46: geyser.SubscribePreprocessedRequest.TransactionsEntry
-	nil,                                                    // 47: geyser.SubscribeRequest.AccountsEntry
-	nil,                                                    // 48: geyser.SubscribeRequest.SlotsEntry
-	nil,                                                    // 49: geyser.SubscribeRequest.TransactionsEntry
-	nil,                                                    // 50: geyser.SubscribeRequest.TransactionsStatusEntry
-	nil,                                                    // 51: geyser.SubscribeRequest.BlocksEntry
-	nil,                                                    // 52: geyser.SubscribeRequest.BlocksMetaEntry
-	nil,                                                    // 53: geyser.SubscribeRequest.EntryEntry
-	(*timestamppb.Timestamp)(nil),                          // 54: google.protobuf.Timestamp
-	(*Transaction)(nil),                                    // 55: solana.storage.ConfirmedBlock.Transaction
-	(*TransactionStatusMeta)(nil),                          // 56: solana.storage.ConfirmedBlock.TransactionStatusMeta
-	(*TransactionError)(nil),                               // 57: solana.storage.ConfirmedBlock.TransactionError
-	(*Rewards)(nil),                                        // 58: solana.storage.ConfirmedBlock.Rewards
-	(*UnixTimestamp)(nil),                                  // 59: solana.storage.ConfirmedBlock.UnixTimestamp
-	(*BlockHeight)(nil),                                    // 60: solana.storage.ConfirmedBlock.BlockHeight
+	(TokenAccountExpansionControlFlag)(0),                  // 2: geyser.TokenAccountExpansionControlFlag
+	(*SubscribePreprocessedRequest)(nil),                   // 3: geyser.SubscribePreprocessedRequest
+	(*SubscribePreprocessedRequestFilterTransactions)(nil), // 4: geyser.SubscribePreprocessedRequestFilterTransactions
+	(*SubscribePreprocessedUpdate)(nil),                    // 5: geyser.SubscribePreprocessedUpdate
+	(*SubscribePreprocessedTransaction)(nil),               // 6: geyser.SubscribePreprocessedTransaction
+	(*SubscribePreprocessedTransactionInfo)(nil),           // 7: geyser.SubscribePreprocessedTransactionInfo
+	(*SubscribeRequest)(nil),                               // 8: geyser.SubscribeRequest
+	(*SubscribeRequestFilterAccounts)(nil),                 // 9: geyser.SubscribeRequestFilterAccounts
+	(*SubscribeRequestFilterAccountsFilter)(nil),           // 10: geyser.SubscribeRequestFilterAccountsFilter
+	(*SubscribeRequestFilterAccountsFilterMemcmp)(nil),     // 11: geyser.SubscribeRequestFilterAccountsFilterMemcmp
+	(*SubscribeRequestFilterAccountsFilterLamports)(nil),   // 12: geyser.SubscribeRequestFilterAccountsFilterLamports
+	(*SubscribeRequestFilterSlots)(nil),                    // 13: geyser.SubscribeRequestFilterSlots
+	(*SubscribeRequestFilterTransactions)(nil),             // 14: geyser.SubscribeRequestFilterTransactions
+	(*SubscribeRequestFilterBlocks)(nil),                   // 15: geyser.SubscribeRequestFilterBlocks
+	(*SubscribeRequestFilterBlocksMeta)(nil),               // 16: geyser.SubscribeRequestFilterBlocksMeta
+	(*SubscribeRequestFilterEntry)(nil),                    // 17: geyser.SubscribeRequestFilterEntry
+	(*SubscribeRequestAccountsDataSlice)(nil),              // 18: geyser.SubscribeRequestAccountsDataSlice
+	(*SubscribeRequestPing)(nil),                           // 19: geyser.SubscribeRequestPing
+	(*SubscribeUpdate)(nil),                                // 20: geyser.SubscribeUpdate
+	(*SubscribeUpdateBatch)(nil),                           // 21: geyser.SubscribeUpdateBatch
+	(*SubscribeUpdateAccount)(nil),                         // 22: geyser.SubscribeUpdateAccount
+	(*SubscribeUpdateAccountInfo)(nil),                     // 23: geyser.SubscribeUpdateAccountInfo
+	(*SubscribeUpdateSlot)(nil),                            // 24: geyser.SubscribeUpdateSlot
+	(*SubscribeUpdateTransaction)(nil),                     // 25: geyser.SubscribeUpdateTransaction
+	(*SubscribeUpdateTransactionInfo)(nil),                 // 26: geyser.SubscribeUpdateTransactionInfo
+	(*SubscribeUpdateTransactionStatus)(nil),               // 27: geyser.SubscribeUpdateTransactionStatus
+	(*SubscribeUpdateBlock)(nil),                           // 28: geyser.SubscribeUpdateBlock
+	(*SubscribeUpdateBlockMeta)(nil),                       // 29: geyser.SubscribeUpdateBlockMeta
+	(*SubscribeUpdateEntry)(nil),                           // 30: geyser.SubscribeUpdateEntry
+	(*SubscribeUpdatePing)(nil),                            // 31: geyser.SubscribeUpdatePing
+	(*SubscribeUpdatePong)(nil),                            // 32: geyser.SubscribeUpdatePong
+	(*SubscribeReplayInfoRequest)(nil),                     // 33: geyser.SubscribeReplayInfoRequest
+	(*SubscribeReplayInfoResponse)(nil),                    // 34: geyser.SubscribeReplayInfoResponse
+	(*PingRequest)(nil),                                    // 35: geyser.PingRequest
+	(*PongResponse)(nil),                                   // 36: geyser.PongResponse
+	(*GetLatestBlockhashRequest)(nil),                      // 37: geyser.GetLatestBlockhashRequest
+	(*GetLatestBlockhashResponse)(nil),                     // 38: geyser.GetLatestBlockhashResponse
+	(*GetBlockHeightRequest)(nil),                          // 39: geyser.GetBlockHeightRequest
+	(*GetBlockHeightResponse)(nil),                         // 40: geyser.GetBlockHeightResponse
+	(*GetSlotRequest)(nil),                                 // 41: geyser.GetSlotRequest
+	(*GetSlotResponse)(nil),                                // 42: geyser.GetSlotResponse
+	(*GetVersionRequest)(nil),                              // 43: geyser.GetVersionRequest
+	(*GetVersionResponse)(nil),                             // 44: geyser.GetVersionResponse
+	(*IsBlockhashValidRequest)(nil),                        // 45: geyser.IsBlockhashValidRequest
+	(*IsBlockhashValidResponse)(nil),                       // 46: geyser.IsBlockhashValidResponse
+	nil,                                                    // 47: geyser.SubscribePreprocessedRequest.TransactionsEntry
+	nil,                                                    // 48: geyser.SubscribeRequest.AccountsEntry
+	nil,                                                    // 49: geyser.SubscribeRequest.SlotsEntry
+	nil,                                                    // 50: geyser.SubscribeRequest.TransactionsEntry
+	nil,                                                    // 51: geyser.SubscribeRequest.TransactionsStatusEntry
+	nil,                                                    // 52: geyser.SubscribeRequest.BlocksEntry
+	nil,                                                    // 53: geyser.SubscribeRequest.BlocksMetaEntry
+	nil,                                                    // 54: geyser.SubscribeRequest.EntryEntry
+	(*timestamppb.Timestamp)(nil),                          // 55: google.protobuf.Timestamp
+	(*Transaction)(nil),                                    // 56: solana.storage.ConfirmedBlock.Transaction
+	(*TransactionStatusMeta)(nil),                          // 57: solana.storage.ConfirmedBlock.TransactionStatusMeta
+	(*TransactionError)(nil),                               // 58: solana.storage.ConfirmedBlock.TransactionError
+	(*Rewards)(nil),                                        // 59: solana.storage.ConfirmedBlock.Rewards
+	(*UnixTimestamp)(nil),                                  // 60: solana.storage.ConfirmedBlock.UnixTimestamp
+	(*BlockHeight)(nil),                                    // 61: solana.storage.ConfirmedBlock.BlockHeight
 }
 var file_geyser_proto_depIdxs = []int32{
-	46, // 0: geyser.SubscribePreprocessedRequest.transactions:type_name -> geyser.SubscribePreprocessedRequest.TransactionsEntry
-	18, // 1: geyser.SubscribePreprocessedRequest.ping:type_name -> geyser.SubscribeRequestPing
-	5,  // 2: geyser.SubscribePreprocessedUpdate.transaction:type_name -> geyser.SubscribePreprocessedTransaction
-	30, // 3: geyser.SubscribePreprocessedUpdate.ping:type_name -> geyser.SubscribeUpdatePing
-	31, // 4: geyser.SubscribePreprocessedUpdate.pong:type_name -> geyser.SubscribeUpdatePong
-	54, // 5: geyser.SubscribePreprocessedUpdate.created_at:type_name -> google.protobuf.Timestamp
-	6,  // 6: geyser.SubscribePreprocessedTransaction.transaction:type_name -> geyser.SubscribePreprocessedTransactionInfo
-	55, // 7: geyser.SubscribePreprocessedTransactionInfo.transaction:type_name -> solana.storage.ConfirmedBlock.Transaction
-	47, // 8: geyser.SubscribeRequest.accounts:type_name -> geyser.SubscribeRequest.AccountsEntry
-	48, // 9: geyser.SubscribeRequest.slots:type_name -> geyser.SubscribeRequest.SlotsEntry
-	49, // 10: geyser.SubscribeRequest.transactions:type_name -> geyser.SubscribeRequest.TransactionsEntry
-	50, // 11: geyser.SubscribeRequest.transactions_status:type_name -> geyser.SubscribeRequest.TransactionsStatusEntry
-	51, // 12: geyser.SubscribeRequest.blocks:type_name -> geyser.SubscribeRequest.BlocksEntry
-	52, // 13: geyser.SubscribeRequest.blocks_meta:type_name -> geyser.SubscribeRequest.BlocksMetaEntry
-	53, // 14: geyser.SubscribeRequest.entry:type_name -> geyser.SubscribeRequest.EntryEntry
+	47, // 0: geyser.SubscribePreprocessedRequest.transactions:type_name -> geyser.SubscribePreprocessedRequest.TransactionsEntry
+	19, // 1: geyser.SubscribePreprocessedRequest.ping:type_name -> geyser.SubscribeRequestPing
+	6,  // 2: geyser.SubscribePreprocessedUpdate.transaction:type_name -> geyser.SubscribePreprocessedTransaction
+	31, // 3: geyser.SubscribePreprocessedUpdate.ping:type_name -> geyser.SubscribeUpdatePing
+	32, // 4: geyser.SubscribePreprocessedUpdate.pong:type_name -> geyser.SubscribeUpdatePong
+	55, // 5: geyser.SubscribePreprocessedUpdate.created_at:type_name -> google.protobuf.Timestamp
+	7,  // 6: geyser.SubscribePreprocessedTransaction.transaction:type_name -> geyser.SubscribePreprocessedTransactionInfo
+	56, // 7: geyser.SubscribePreprocessedTransactionInfo.transaction:type_name -> solana.storage.ConfirmedBlock.Transaction
+	48, // 8: geyser.SubscribeRequest.accounts:type_name -> geyser.SubscribeRequest.AccountsEntry
+	49, // 9: geyser.SubscribeRequest.slots:type_name -> geyser.SubscribeRequest.SlotsEntry
+	50, // 10: geyser.SubscribeRequest.transactions:type_name -> geyser.SubscribeRequest.TransactionsEntry
+	51, // 11: geyser.SubscribeRequest.transactions_status:type_name -> geyser.SubscribeRequest.TransactionsStatusEntry
+	52, // 12: geyser.SubscribeRequest.blocks:type_name -> geyser.SubscribeRequest.BlocksEntry
+	53, // 13: geyser.SubscribeRequest.blocks_meta:type_name -> geyser.SubscribeRequest.BlocksMetaEntry
+	54, // 14: geyser.SubscribeRequest.entry:type_name -> geyser.SubscribeRequest.EntryEntry
 	0,  // 15: geyser.SubscribeRequest.commitment:type_name -> geyser.CommitmentLevel
-	17, // 16: geyser.SubscribeRequest.accounts_data_slice:type_name -> geyser.SubscribeRequestAccountsDataSlice
-	18, // 17: geyser.SubscribeRequest.ping:type_name -> geyser.SubscribeRequestPing
-	9,  // 18: geyser.SubscribeRequestFilterAccounts.filters:type_name -> geyser.SubscribeRequestFilterAccountsFilter
-	10, // 19: geyser.SubscribeRequestFilterAccountsFilter.memcmp:type_name -> geyser.SubscribeRequestFilterAccountsFilterMemcmp
-	11, // 20: geyser.SubscribeRequestFilterAccountsFilter.lamports:type_name -> geyser.SubscribeRequestFilterAccountsFilterLamports
-	21, // 21: geyser.SubscribeUpdate.account:type_name -> geyser.SubscribeUpdateAccount
-	23, // 22: geyser.SubscribeUpdate.slot:type_name -> geyser.SubscribeUpdateSlot
-	24, // 23: geyser.SubscribeUpdate.transaction:type_name -> geyser.SubscribeUpdateTransaction
-	26, // 24: geyser.SubscribeUpdate.transaction_status:type_name -> geyser.SubscribeUpdateTransactionStatus
-	27, // 25: geyser.SubscribeUpdate.block:type_name -> geyser.SubscribeUpdateBlock
-	30, // 26: geyser.SubscribeUpdate.ping:type_name -> geyser.SubscribeUpdatePing
-	31, // 27: geyser.SubscribeUpdate.pong:type_name -> geyser.SubscribeUpdatePong
-	28, // 28: geyser.SubscribeUpdate.block_meta:type_name -> geyser.SubscribeUpdateBlockMeta
-	29, // 29: geyser.SubscribeUpdate.entry:type_name -> geyser.SubscribeUpdateEntry
-	54, // 30: geyser.SubscribeUpdate.created_at:type_name -> google.protobuf.Timestamp
-	19, // 31: geyser.SubscribeUpdateBatch.updates:type_name -> geyser.SubscribeUpdate
-	22, // 32: geyser.SubscribeUpdateAccount.account:type_name -> geyser.SubscribeUpdateAccountInfo
-	1,  // 33: geyser.SubscribeUpdateSlot.status:type_name -> geyser.SlotStatus
-	25, // 34: geyser.SubscribeUpdateTransaction.transaction:type_name -> geyser.SubscribeUpdateTransactionInfo
-	55, // 35: geyser.SubscribeUpdateTransactionInfo.transaction:type_name -> solana.storage.ConfirmedBlock.Transaction
-	56, // 36: geyser.SubscribeUpdateTransactionInfo.meta:type_name -> solana.storage.ConfirmedBlock.TransactionStatusMeta
-	57, // 37: geyser.SubscribeUpdateTransactionStatus.err:type_name -> solana.storage.ConfirmedBlock.TransactionError
-	58, // 38: geyser.SubscribeUpdateBlock.rewards:type_name -> solana.storage.ConfirmedBlock.Rewards
-	59, // 39: geyser.SubscribeUpdateBlock.block_time:type_name -> solana.storage.ConfirmedBlock.UnixTimestamp
-	60, // 40: geyser.SubscribeUpdateBlock.block_height:type_name -> solana.storage.ConfirmedBlock.BlockHeight
-	25, // 41: geyser.SubscribeUpdateBlock.transactions:type_name -> geyser.SubscribeUpdateTransactionInfo
-	22, // 42: geyser.SubscribeUpdateBlock.accounts:type_name -> geyser.SubscribeUpdateAccountInfo
-	29, // 43: geyser.SubscribeUpdateBlock.entries:type_name -> geyser.SubscribeUpdateEntry
-	58, // 44: geyser.SubscribeUpdateBlockMeta.rewards:type_name -> solana.storage.ConfirmedBlock.Rewards
-	59, // 45: geyser.SubscribeUpdateBlockMeta.block_time:type_name -> solana.storage.ConfirmedBlock.UnixTimestamp
-	60, // 46: geyser.SubscribeUpdateBlockMeta.block_height:type_name -> solana.storage.ConfirmedBlock.BlockHeight
-	0,  // 47: geyser.GetLatestBlockhashRequest.commitment:type_name -> geyser.CommitmentLevel
-	0,  // 48: geyser.GetBlockHeightRequest.commitment:type_name -> geyser.CommitmentLevel
-	0,  // 49: geyser.GetSlotRequest.commitment:type_name -> geyser.CommitmentLevel
-	0,  // 50: geyser.IsBlockhashValidRequest.commitment:type_name -> geyser.CommitmentLevel
-	3,  // 51: geyser.SubscribePreprocessedRequest.TransactionsEntry.value:type_name -> geyser.SubscribePreprocessedRequestFilterTransactions
-	8,  // 52: geyser.SubscribeRequest.AccountsEntry.value:type_name -> geyser.SubscribeRequestFilterAccounts
-	12, // 53: geyser.SubscribeRequest.SlotsEntry.value:type_name -> geyser.SubscribeRequestFilterSlots
-	13, // 54: geyser.SubscribeRequest.TransactionsEntry.value:type_name -> geyser.SubscribeRequestFilterTransactions
-	13, // 55: geyser.SubscribeRequest.TransactionsStatusEntry.value:type_name -> geyser.SubscribeRequestFilterTransactions
-	14, // 56: geyser.SubscribeRequest.BlocksEntry.value:type_name -> geyser.SubscribeRequestFilterBlocks
-	15, // 57: geyser.SubscribeRequest.BlocksMetaEntry.value:type_name -> geyser.SubscribeRequestFilterBlocksMeta
-	16, // 58: geyser.SubscribeRequest.EntryEntry.value:type_name -> geyser.SubscribeRequestFilterEntry
-	7,  // 59: geyser.Geyser.Subscribe:input_type -> geyser.SubscribeRequest
-	2,  // 60: geyser.Geyser.SubscribePreprocessed:input_type -> geyser.SubscribePreprocessedRequest
-	32, // 61: geyser.Geyser.SubscribeReplayInfo:input_type -> geyser.SubscribeReplayInfoRequest
-	34, // 62: geyser.Geyser.Ping:input_type -> geyser.PingRequest
-	36, // 63: geyser.Geyser.GetLatestBlockhash:input_type -> geyser.GetLatestBlockhashRequest
-	38, // 64: geyser.Geyser.GetBlockHeight:input_type -> geyser.GetBlockHeightRequest
-	40, // 65: geyser.Geyser.GetSlot:input_type -> geyser.GetSlotRequest
-	44, // 66: geyser.Geyser.IsBlockhashValid:input_type -> geyser.IsBlockhashValidRequest
-	42, // 67: geyser.Geyser.GetVersion:input_type -> geyser.GetVersionRequest
-	19, // 68: geyser.Geyser.Subscribe:output_type -> geyser.SubscribeUpdate
-	4,  // 69: geyser.Geyser.SubscribePreprocessed:output_type -> geyser.SubscribePreprocessedUpdate
-	33, // 70: geyser.Geyser.SubscribeReplayInfo:output_type -> geyser.SubscribeReplayInfoResponse
-	35, // 71: geyser.Geyser.Ping:output_type -> geyser.PongResponse
-	37, // 72: geyser.Geyser.GetLatestBlockhash:output_type -> geyser.GetLatestBlockhashResponse
-	39, // 73: geyser.Geyser.GetBlockHeight:output_type -> geyser.GetBlockHeightResponse
-	41, // 74: geyser.Geyser.GetSlot:output_type -> geyser.GetSlotResponse
-	45, // 75: geyser.Geyser.IsBlockhashValid:output_type -> geyser.IsBlockhashValidResponse
-	43, // 76: geyser.Geyser.GetVersion:output_type -> geyser.GetVersionResponse
-	68, // [68:77] is the sub-list for method output_type
-	59, // [59:68] is the sub-list for method input_type
-	59, // [59:59] is the sub-list for extension type_name
-	59, // [59:59] is the sub-list for extension extendee
-	0,  // [0:59] is the sub-list for field type_name
+	18, // 16: geyser.SubscribeRequest.accounts_data_slice:type_name -> geyser.SubscribeRequestAccountsDataSlice
+	19, // 17: geyser.SubscribeRequest.ping:type_name -> geyser.SubscribeRequestPing
+	10, // 18: geyser.SubscribeRequestFilterAccounts.filters:type_name -> geyser.SubscribeRequestFilterAccountsFilter
+	11, // 19: geyser.SubscribeRequestFilterAccountsFilter.memcmp:type_name -> geyser.SubscribeRequestFilterAccountsFilterMemcmp
+	12, // 20: geyser.SubscribeRequestFilterAccountsFilter.lamports:type_name -> geyser.SubscribeRequestFilterAccountsFilterLamports
+	2,  // 21: geyser.SubscribeRequestFilterTransactions.token_accounts:type_name -> geyser.TokenAccountExpansionControlFlag
+	22, // 22: geyser.SubscribeUpdate.account:type_name -> geyser.SubscribeUpdateAccount
+	24, // 23: geyser.SubscribeUpdate.slot:type_name -> geyser.SubscribeUpdateSlot
+	25, // 24: geyser.SubscribeUpdate.transaction:type_name -> geyser.SubscribeUpdateTransaction
+	27, // 25: geyser.SubscribeUpdate.transaction_status:type_name -> geyser.SubscribeUpdateTransactionStatus
+	28, // 26: geyser.SubscribeUpdate.block:type_name -> geyser.SubscribeUpdateBlock
+	31, // 27: geyser.SubscribeUpdate.ping:type_name -> geyser.SubscribeUpdatePing
+	32, // 28: geyser.SubscribeUpdate.pong:type_name -> geyser.SubscribeUpdatePong
+	29, // 29: geyser.SubscribeUpdate.block_meta:type_name -> geyser.SubscribeUpdateBlockMeta
+	30, // 30: geyser.SubscribeUpdate.entry:type_name -> geyser.SubscribeUpdateEntry
+	55, // 31: geyser.SubscribeUpdate.created_at:type_name -> google.protobuf.Timestamp
+	20, // 32: geyser.SubscribeUpdateBatch.updates:type_name -> geyser.SubscribeUpdate
+	23, // 33: geyser.SubscribeUpdateAccount.account:type_name -> geyser.SubscribeUpdateAccountInfo
+	1,  // 34: geyser.SubscribeUpdateSlot.status:type_name -> geyser.SlotStatus
+	26, // 35: geyser.SubscribeUpdateTransaction.transaction:type_name -> geyser.SubscribeUpdateTransactionInfo
+	56, // 36: geyser.SubscribeUpdateTransactionInfo.transaction:type_name -> solana.storage.ConfirmedBlock.Transaction
+	57, // 37: geyser.SubscribeUpdateTransactionInfo.meta:type_name -> solana.storage.ConfirmedBlock.TransactionStatusMeta
+	58, // 38: geyser.SubscribeUpdateTransactionStatus.err:type_name -> solana.storage.ConfirmedBlock.TransactionError
+	59, // 39: geyser.SubscribeUpdateBlock.rewards:type_name -> solana.storage.ConfirmedBlock.Rewards
+	60, // 40: geyser.SubscribeUpdateBlock.block_time:type_name -> solana.storage.ConfirmedBlock.UnixTimestamp
+	61, // 41: geyser.SubscribeUpdateBlock.block_height:type_name -> solana.storage.ConfirmedBlock.BlockHeight
+	26, // 42: geyser.SubscribeUpdateBlock.transactions:type_name -> geyser.SubscribeUpdateTransactionInfo
+	23, // 43: geyser.SubscribeUpdateBlock.accounts:type_name -> geyser.SubscribeUpdateAccountInfo
+	30, // 44: geyser.SubscribeUpdateBlock.entries:type_name -> geyser.SubscribeUpdateEntry
+	59, // 45: geyser.SubscribeUpdateBlockMeta.rewards:type_name -> solana.storage.ConfirmedBlock.Rewards
+	60, // 46: geyser.SubscribeUpdateBlockMeta.block_time:type_name -> solana.storage.ConfirmedBlock.UnixTimestamp
+	61, // 47: geyser.SubscribeUpdateBlockMeta.block_height:type_name -> solana.storage.ConfirmedBlock.BlockHeight
+	0,  // 48: geyser.GetLatestBlockhashRequest.commitment:type_name -> geyser.CommitmentLevel
+	0,  // 49: geyser.GetBlockHeightRequest.commitment:type_name -> geyser.CommitmentLevel
+	0,  // 50: geyser.GetSlotRequest.commitment:type_name -> geyser.CommitmentLevel
+	0,  // 51: geyser.IsBlockhashValidRequest.commitment:type_name -> geyser.CommitmentLevel
+	4,  // 52: geyser.SubscribePreprocessedRequest.TransactionsEntry.value:type_name -> geyser.SubscribePreprocessedRequestFilterTransactions
+	9,  // 53: geyser.SubscribeRequest.AccountsEntry.value:type_name -> geyser.SubscribeRequestFilterAccounts
+	13, // 54: geyser.SubscribeRequest.SlotsEntry.value:type_name -> geyser.SubscribeRequestFilterSlots
+	14, // 55: geyser.SubscribeRequest.TransactionsEntry.value:type_name -> geyser.SubscribeRequestFilterTransactions
+	14, // 56: geyser.SubscribeRequest.TransactionsStatusEntry.value:type_name -> geyser.SubscribeRequestFilterTransactions
+	15, // 57: geyser.SubscribeRequest.BlocksEntry.value:type_name -> geyser.SubscribeRequestFilterBlocks
+	16, // 58: geyser.SubscribeRequest.BlocksMetaEntry.value:type_name -> geyser.SubscribeRequestFilterBlocksMeta
+	17, // 59: geyser.SubscribeRequest.EntryEntry.value:type_name -> geyser.SubscribeRequestFilterEntry
+	8,  // 60: geyser.Geyser.Subscribe:input_type -> geyser.SubscribeRequest
+	3,  // 61: geyser.Geyser.SubscribePreprocessed:input_type -> geyser.SubscribePreprocessedRequest
+	33, // 62: geyser.Geyser.SubscribeReplayInfo:input_type -> geyser.SubscribeReplayInfoRequest
+	35, // 63: geyser.Geyser.Ping:input_type -> geyser.PingRequest
+	37, // 64: geyser.Geyser.GetLatestBlockhash:input_type -> geyser.GetLatestBlockhashRequest
+	39, // 65: geyser.Geyser.GetBlockHeight:input_type -> geyser.GetBlockHeightRequest
+	41, // 66: geyser.Geyser.GetSlot:input_type -> geyser.GetSlotRequest
+	45, // 67: geyser.Geyser.IsBlockhashValid:input_type -> geyser.IsBlockhashValidRequest
+	43, // 68: geyser.Geyser.GetVersion:input_type -> geyser.GetVersionRequest
+	20, // 69: geyser.Geyser.Subscribe:output_type -> geyser.SubscribeUpdate
+	5,  // 70: geyser.Geyser.SubscribePreprocessed:output_type -> geyser.SubscribePreprocessedUpdate
+	34, // 71: geyser.Geyser.SubscribeReplayInfo:output_type -> geyser.SubscribeReplayInfoResponse
+	36, // 72: geyser.Geyser.Ping:output_type -> geyser.PongResponse
+	38, // 73: geyser.Geyser.GetLatestBlockhash:output_type -> geyser.GetLatestBlockhashResponse
+	40, // 74: geyser.Geyser.GetBlockHeight:output_type -> geyser.GetBlockHeightResponse
+	42, // 75: geyser.Geyser.GetSlot:output_type -> geyser.GetSlotResponse
+	46, // 76: geyser.Geyser.IsBlockhashValid:output_type -> geyser.IsBlockhashValidResponse
+	44, // 77: geyser.Geyser.GetVersion:output_type -> geyser.GetVersionResponse
+	69, // [69:78] is the sub-list for method output_type
+	60, // [60:69] is the sub-list for method input_type
+	60, // [60:60] is the sub-list for extension type_name
+	60, // [60:60] is the sub-list for extension extendee
+	0,  // [0:60] is the sub-list for field type_name
 }
 
 func init() { file_geyser_proto_init() }
@@ -3646,7 +3715,7 @@ func file_geyser_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_geyser_proto_rawDesc), len(file_geyser_proto_rawDesc)),
-			NumEnums:      2,
+			NumEnums:      3,
 			NumMessages:   52,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/go/proto/geyser.proto
+++ b/go/proto/geyser.proto
@@ -131,6 +131,20 @@ message SubscribeRequestFilterTransactions {
   repeated string account_include = 3;
   repeated string account_exclude = 4;
   repeated string account_required = 6;
+  // Helius extension: ATA / token-account expansion control. When set,
+  // account_include / account_exclude / account_required also match
+  // against owners of pre/post token balances on each transaction.
+  // Absent = no expansion.
+  optional TokenAccountExpansionControlFlag token_accounts = 30;
+}
+
+// Helius extension: discriminator for `SubscribeRequestFilterTransactions.token_accounts`.
+enum TokenAccountExpansionControlFlag {
+  // Match an owner if it owns a pre OR post token balance on the tx.
+  ALL = 0;
+  // Match an owner whose token balance changed in amount (per
+  // `account_index`) or whose token account was closed.
+  BALANCE_CHANGED = 1;
 }
 
 message SubscribeRequestFilterBlocks {

--- a/go/proto/token_accounts_test.go
+++ b/go/proto/token_accounts_test.go
@@ -1,0 +1,92 @@
+package proto
+
+import (
+	"bytes"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// Wire-format conformance for the Helius `token_accounts` extension
+// (SubscribeRequestFilterTransactions field #30, enum
+// TokenAccountExpansionControlFlag). The expected bytes must match what the
+// Rust and JS SDKs emit for the same filter: tag 0xF0 0x01 (field 30,
+// varint) followed by the enum value.
+func TestTokenAccountsWireFormat(t *testing.T) {
+	cases := []struct {
+		name string
+		mode TokenAccountExpansionControlFlag
+		want []byte
+	}{
+		{"ALL", TokenAccountExpansionControlFlag_ALL, []byte{0xF0, 0x01, 0x00}},
+		{"BALANCE_CHANGED", TokenAccountExpansionControlFlag_BALANCE_CHANGED, []byte{0xF0, 0x01, 0x01}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &SubscribeRequestFilterTransactions{TokenAccounts: tc.mode.Enum()}
+			got, err := proto.Marshal(f)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if !bytes.Equal(got, tc.want) {
+				t.Fatalf("marshal(%s) = %x, want %x", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// Unset must stay absent on the wire (no expansion), and explicit presence —
+// including the zero value ALL — must survive a marshal/unmarshal roundtrip.
+func TestTokenAccountsPresence(t *testing.T) {
+	unset, err := proto.Marshal(&SubscribeRequestFilterTransactions{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if len(unset) != 0 {
+		t.Fatalf("unset filter marshaled to %x, want empty", unset)
+	}
+
+	for _, mode := range []TokenAccountExpansionControlFlag{
+		TokenAccountExpansionControlFlag_ALL,
+		TokenAccountExpansionControlFlag_BALANCE_CHANGED,
+	} {
+		data, err := proto.Marshal(&SubscribeRequestFilterTransactions{TokenAccounts: mode.Enum()})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var back SubscribeRequestFilterTransactions
+		if err := proto.Unmarshal(data, &back); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if back.TokenAccounts == nil || *back.TokenAccounts != mode {
+			t.Fatalf("roundtrip of %v lost presence or value: %v", mode, back.TokenAccounts)
+		}
+	}
+}
+
+// The field must coexist with the rest of the filter and survive proto.Clone,
+// which the SDK uses internally for reconnect/replay requests.
+func TestTokenAccountsCloneAndFullFilter(t *testing.T) {
+	vote, failed := false, false
+	f := &SubscribeRequestFilterTransactions{
+		Vote:           &vote,
+		Failed:         &failed,
+		AccountInclude: []string{"vines1vzrYbzLMRdu58ou5XTby4qAqVRLmqo36NKPTg"},
+		TokenAccounts:  TokenAccountExpansionControlFlag_BALANCE_CHANGED.Enum(),
+	}
+	clone := proto.Clone(f).(*SubscribeRequestFilterTransactions)
+	if clone.GetTokenAccounts() != TokenAccountExpansionControlFlag_BALANCE_CHANGED {
+		t.Fatalf("clone lost token_accounts: %v", clone.TokenAccounts)
+	}
+	data, err := proto.Marshal(f)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back SubscribeRequestFilterTransactions
+	if err := proto.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !proto.Equal(f, &back) {
+		t.Fatalf("roundtrip mismatch: %v vs %v", f, &back)
+	}
+}

--- a/go/test/token-accounts-e2e.go
+++ b/go/test/token-accounts-e2e.go
@@ -1,0 +1,243 @@
+// Live e2e for the tokenAccounts (ATA expansion) transaction filter.
+//
+// One stream, three filters over the same wallet:
+//
+//	base — plain AccountInclude (no expansion)
+//	bc   — TokenAccounts: BALANCE_CHANGED
+//	all  — TokenAccounts: ALL
+//
+// SubscribeUpdate.Filters tells us which filters matched each tx, so we can
+// verify:
+//  1. bc / all are supersets of base;
+//  2. expansion-only matches exist where the wallet pubkey is NOT among the
+//     tx account keys (incl. loaded ALT addresses) but IS an owner in
+//     pre/post token balances — proof the server matched via owner
+//     resolution, not the static key list;
+//  3. Write() with a tokenAccounts filter keeps the stream working.
+//
+// Usage: go run test/token-accounts-e2e.go <endpoint> <api-key> <wallet> [seconds]
+package main
+
+import (
+	"fmt"
+	"math/big"
+	"os"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	laserstream "github.com/helius-labs/laserstream-sdk/go"
+)
+
+const b58Alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+func base58Encode(b []byte) string {
+	x := new(big.Int).SetBytes(b)
+	base := big.NewInt(58)
+	mod := new(big.Int)
+	var out []byte
+	for x.Sign() > 0 {
+		x.DivMod(x, base, mod)
+		out = append(out, b58Alphabet[mod.Int64()])
+	}
+	for _, c := range b {
+		if c != 0 {
+			break
+		}
+		out = append(out, '1')
+	}
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return string(out)
+}
+
+type stats struct {
+	mu             sync.Mutex
+	counts         map[string]int
+	expansionOnly  int // matched bc/all but not base
+	expansionProof int // expansion-only AND wallet absent from account keys AND wallet owns a token balance
+	baseNotBc      int // matched base but not bc (expected: base ⊆ all, bc can differ)
+	sampleSigs     []string
+	postWriteBc    int
+	errors         []string
+}
+
+func main() {
+	if len(os.Args) < 4 {
+		fmt.Println("usage: token-accounts-e2e <endpoint> <api-key> <wallet> [seconds]")
+		os.Exit(2)
+	}
+	endpoint, apiKey, wallet := os.Args[1], os.Args[2], os.Args[3]
+	runSecs := 90
+	if len(os.Args) > 4 {
+		runSecs, _ = strconv.Atoi(os.Args[4])
+	}
+
+	s := &stats{counts: map[string]int{}}
+	commitment := laserstream.CommitmentLevel_PROCESSED
+	vote, failed := false, false
+
+	newFilter := func(mode *laserstream.TokenAccountExpansionControlFlag) *laserstream.SubscribeRequestFilterTransactions {
+		return &laserstream.SubscribeRequestFilterTransactions{
+			AccountInclude: []string{wallet},
+			Vote:           &vote,
+			Failed:         &failed,
+			TokenAccounts:  mode,
+		}
+	}
+
+	req := &laserstream.SubscribeRequest{
+		Transactions: map[string]*laserstream.SubscribeRequestFilterTransactions{
+			"base": newFilter(nil),
+			"bc":   newFilter(laserstream.TokenAccountExpansionControlFlag_BALANCE_CHANGED.Enum()),
+			"all":  newFilter(laserstream.TokenAccountExpansionControlFlag_ALL.Enum()),
+		},
+		Commitment: &commitment,
+	}
+
+	client := laserstream.NewClient(laserstream.LaserstreamConfig{Endpoint: endpoint, APIKey: apiKey})
+
+	writeAt := time.Now().Add(time.Duration(runSecs/2) * time.Second)
+	var wroteMu sync.Mutex
+	wrote := false
+
+	onData := func(u *laserstream.SubscribeUpdate) {
+		tx := u.GetTransaction()
+		if tx == nil {
+			return
+		}
+		matched := map[string]bool{}
+		for _, f := range u.Filters {
+			matched[f] = true
+		}
+
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		for f := range matched {
+			s.counts[f]++
+		}
+
+		wroteMu.Lock()
+		w := wrote
+		wroteMu.Unlock()
+		if w && matched["bc2"] {
+			s.postWriteBc++
+		}
+
+		if (matched["bc"] || matched["all"]) && !matched["base"] {
+			s.expansionOnly++
+			// Wallet must not be in the static account keys...
+			inKeys := false
+			msg := tx.GetTransaction().GetTransaction().GetMessage()
+			meta := tx.GetTransaction().GetMeta()
+			var keys [][]byte
+			if msg != nil {
+				keys = append(keys, msg.AccountKeys...)
+			}
+			if meta != nil {
+				keys = append(keys, meta.LoadedWritableAddresses...)
+				keys = append(keys, meta.LoadedReadonlyAddresses...)
+			}
+			for _, k := range keys {
+				if base58Encode(k) == wallet {
+					inKeys = true
+					break
+				}
+			}
+			// ...but must own a pre/post token balance.
+			ownsBalance := false
+			if meta != nil {
+				for _, tb := range meta.PreTokenBalances {
+					if tb.Owner == wallet {
+						ownsBalance = true
+					}
+				}
+				for _, tb := range meta.PostTokenBalances {
+					if tb.Owner == wallet {
+						ownsBalance = true
+					}
+				}
+			}
+			if !inKeys && ownsBalance {
+				s.expansionProof++
+				if len(s.sampleSigs) < 5 {
+					s.sampleSigs = append(s.sampleSigs, base58Encode(tx.GetTransaction().GetSignature()))
+				}
+			}
+		}
+		if matched["base"] && !matched["all"] {
+			s.baseNotBc++
+		}
+	}
+
+	onErr := func(err error) {
+		s.mu.Lock()
+		s.errors = append(s.errors, err.Error())
+		s.mu.Unlock()
+		fmt.Printf("stream error: %v\n", err)
+	}
+
+	if err := client.Subscribe(req, onData, onErr); err != nil {
+		fmt.Printf("FAIL subscribe: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("subscribed; running %ds against %s wallet=%s\n", runSecs, endpoint, wallet)
+
+	// Halfway through, exercise Write() with a tokenAccounts filter.
+	go func() {
+		time.Sleep(time.Until(writeAt))
+		wreq := &laserstream.SubscribeRequest{
+			Transactions: map[string]*laserstream.SubscribeRequestFilterTransactions{
+				"base": newFilter(nil),
+				"bc":   newFilter(laserstream.TokenAccountExpansionControlFlag_BALANCE_CHANGED.Enum()),
+				"all":  newFilter(laserstream.TokenAccountExpansionControlFlag_ALL.Enum()),
+				"bc2":  newFilter(laserstream.TokenAccountExpansionControlFlag_BALANCE_CHANGED.Enum()),
+			},
+			Commitment: &commitment,
+		}
+		if err := client.Write(wreq); err != nil {
+			s.mu.Lock()
+			s.errors = append(s.errors, "write: "+err.Error())
+			s.mu.Unlock()
+			fmt.Printf("FAIL write: %v\n", err)
+			return
+		}
+		wroteMu.Lock()
+		wrote = true
+		wroteMu.Unlock()
+		fmt.Println("write() sent: added bc2 filter with BALANCE_CHANGED")
+	}()
+
+	time.Sleep(time.Duration(runSecs) * time.Second)
+	client.Unsubscribe()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var names []string
+	for k := range s.counts {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	fmt.Println("\n=== RESULTS ===")
+	for _, n := range names {
+		fmt.Printf("filter %-5s matched %d txs\n", n, s.counts[n])
+	}
+	fmt.Printf("expansion-only matches (bc/all but not base): %d\n", s.expansionOnly)
+	fmt.Printf("expansion PROOF (wallet not in keys, owns token balance): %d\n", s.expansionProof)
+	fmt.Printf("base-but-not-all (should be 0): %d\n", s.baseNotBc)
+	fmt.Printf("post-write bc2 matches: %d\n", s.postWriteBc)
+	for _, sig := range s.sampleSigs {
+		fmt.Printf("  proof sig: %s\n", sig)
+	}
+	fmt.Printf("stream errors: %d %v\n", len(s.errors), s.errors)
+
+	ok := s.counts["all"] >= s.counts["base"] && s.expansionProof > 0 && s.baseNotBc == 0 && len(s.errors) == 0 && s.postWriteBc > 0
+	if ok {
+		fmt.Println("PASS")
+	} else {
+		fmt.Println("FAIL (see criteria above)")
+		os.Exit(1)
+	}
+}

--- a/rust/README.md
+++ b/rust/README.md
@@ -156,15 +156,18 @@ let request = SubscribeRequest {
 Set `token_accounts` on a transaction filter to also match transactions that
 touch an **Associated Token Account (ATA)** owned by one of the
 `account_include` wallets, not just transactions naming the wallet directly.
-Modes (server wire values):
+Modes:
 
-- `"none"` — no expansion (default; same as leaving the field unset).
-- `"balanceChanged"` — also match txs touching an ATA owned by an
-  `account_include` wallet whose token balance changed.
-- `"all"` — match any tx touching an ATA owned by an `account_include` wallet.
+- unset (`None`) — no expansion (default).
+- `TokenAccountExpansionControlFlag::BalanceChanged` — also match txs touching
+  an ATA owned by an `account_include` wallet whose token balance changed.
+- `TokenAccountExpansionControlFlag::All` — match any tx touching an ATA owned
+  by an `account_include` wallet.
 
 ```rust
-use helius_laserstream::grpc::{SubscribeRequest, SubscribeRequestFilterTransactions};
+use helius_laserstream::grpc::{
+    SubscribeRequest, SubscribeRequestFilterTransactions, TokenAccountExpansionControlFlag,
+};
 
 let request = SubscribeRequest {
     transactions: HashMap::from([(
@@ -173,7 +176,7 @@ let request = SubscribeRequest {
             account_include: vec!["vines1vzrYbzLMRdu58ou5XTby4qAqVRLmqo36NKPTg".to_string()],
             vote: Some(false),
             failed: Some(false),
-            token_accounts: Some("balanceChanged".to_string()),
+            token_accounts: Some(TokenAccountExpansionControlFlag::BalanceChanged as i32),
             ..Default::default()
         },
     )]),


### PR DESCRIPTION
## Summary

The `tokenAccounts` (ATA expansion) transaction filter — already shipped in the Rust and JS SDKs (LS-186, [docs](https://www.helius.dev/docs/laserstream/token-account-filtering)) — was missing from the Go SDK. This PR brings Go to parity:

- **proto**: add `optional TokenAccountExpansionControlFlag token_accounts = 30` + the enum (`ALL = 0`, `BALANCE_CHANGED = 1`) to `go/proto/geyser.proto`, matching the laserstream-core proto on main; regenerate `geyser.pb.go` (protoc 5.29.3 / protoc-gen-go 1.36.10, same versions as the existing file).
- **API**: re-export `TokenAccountExpansionControlFlag` and its values from the `laserstream` package. Usage: `TokenAccounts: laserstream.TokenAccountExpansionControlFlag_BALANCE_CHANGED.Enum()` on a transaction filter. No SDK plumbing needed beyond the proto — the Go client passes `SubscribeRequestFilterTransactions` through verbatim (and `mergeSubscribeRequest`/reconnect use `proto.Clone`, which preserves the field).
- **Docs/examples**: `examples/token-accounts-sub.go`, README section mirroring the Rust/JS ones, `SDKVersion` 0.1.4 → 0.2.0.
- **Drive-by**: fixed the stale Rust README snippet that still showed the pre-enum string API (`token_accounts: Some("balanceChanged".to_string())`), which no longer compiles.

## Testing

- `go/proto/token_accounts_test.go` (new, runs in CI via `go test ./...`):
  - wire-format conformance — marshaled bytes for field 30 are exactly `F0 01 00` / `F0 01 01`, identical to what the Rust/JS SDKs emit;
  - presence semantics — unset stays absent on the wire; explicit `ALL` (enum zero value) survives marshal/unmarshal;
  - `proto.Clone` (the SDK's reconnect/write path) preserves the field.
- `go/test/token-accounts-e2e.go` (new live harness) run on the Pittsburgh debug box against `laserstream-mainnet-pitt` for 120s, one stream with `base` (no expansion) / `bc` (BALANCE_CHANGED) / `all` filters over Binance hot wallet `5tzFki…uAi9`:
  - `base` 59 txs, `bc` 109, `all` 109 — expansion filters are strict supersets of base, zero base-not-in-all violations;
  - **50 expansion-only matches, all 50 verified as true owner-resolution hits**: the wallet was absent from the tx account keys (incl. loaded ALT addresses) but owned a pre/post token balance;
  - `Write()` mid-run adding a fourth BALANCE_CHANGED filter succeeded, 92 matches after the write; stream also survived a reconnect that re-sent the filter set with field 30;
  - zero stream errors, exit `PASS`.
- `go build` / `go vet` / `gofmt` clean on the SDK and proto packages; example compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)