### PR TITLE
Expose V1 TransactionConfig + commission_bps in Rust SDK; cross-SDK golden vectors

### DIFF
--- a/go/v1_config_vectors_test.go
+++ b/go/v1_config_vectors_test.go
@@ -1,0 +1,96 @@
+package laserstream
+
+// Regression vectors for V1 transaction config (SIMD-0385) and
+// Reward.commission_bps (SIMD-0291).
+//
+// The base64 payloads are SubscribeUpdate messages encoded with
+// laserstream-core-proto 11.2.0 (Rust/prost) — the same bytes are asserted
+// against the JS and Rust SDKs, so all three decode identically.
+
+import (
+	"encoding/base64"
+	"testing"
+
+	pb "github.com/helius-labs/laserstream-sdk/go/proto"
+	"google.golang.org/protobuf/proto"
+)
+
+// SubscribeUpdate{transaction} whose message carries TransactionConfig
+const v1ConfigTxB64 = "CgR2ZWMxIpUCCowCCkAHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHGsMBCkAHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHEn8KBAgBGAISIAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBEiACAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAhogCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkoAToPCJS05PTLAxDAuVUggIAQIgAoKhC72ZGsAQ=="
+
+// SubscribeUpdate{block} whose rewards carry commission_bps
+const commissionBpsBlockB64 = "CgR2ZWMyKoYBCLzZkawBEgR0ZXN0GngKPgorVm90ZTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMRCIJxigjQYgBCoBNTIDNTUwCjYKK1N0YWtlMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEQj04YwJoMIAM="
+
+func mustDecode(t *testing.T, b64 string) *pb.SubscribeUpdate {
+	t.Helper()
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		t.Fatalf("bad base64: %v", err)
+	}
+	var update pb.SubscribeUpdate
+	if err := proto.Unmarshal(raw, &update); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return &update
+}
+
+func TestV1TransactionConfigDecodes(t *testing.T) {
+	update := mustDecode(t, v1ConfigTxB64)
+
+	tx := update.GetTransaction()
+	if tx == nil {
+		t.Fatal("expected transaction update")
+	}
+	if tx.GetSlot() != 361000123 {
+		t.Fatalf("slot = %d, want 361000123", tx.GetSlot())
+	}
+
+	msg := tx.GetTransaction().GetTransaction().GetMessage()
+	if !msg.GetVersioned() {
+		t.Fatal("expected versioned = true")
+	}
+	cfg := msg.GetConfig()
+	if cfg == nil {
+		t.Fatal("expected message.config to be present for V1")
+	}
+	if got := cfg.GetPriorityFee(); got != 123456789012 {
+		t.Fatalf("priority_fee = %d, want 123456789012", got)
+	}
+	if got := cfg.GetComputeUnitLimit(); got != 1400000 {
+		t.Fatalf("compute_unit_limit = %d, want 1400000", got)
+	}
+	if got := cfg.GetHeapSize(); got != 262144 {
+		t.Fatalf("heap_size = %d, want 262144", got)
+	}
+	if cfg.LoadedAccountsDataSizeLimit != nil {
+		t.Fatal("loaded_accounts_data_size_limit must be absent")
+	}
+}
+
+func TestRewardCommissionBpsDecodes(t *testing.T) {
+	update := mustDecode(t, commissionBpsBlockB64)
+
+	block := update.GetBlock()
+	if block == nil {
+		t.Fatal("expected block update")
+	}
+	rewards := block.GetRewards().GetRewards()
+	if len(rewards) != 2 {
+		t.Fatalf("rewards = %d, want 2", len(rewards))
+	}
+
+	if got := rewards[0].GetCommissionBps(); got != "550" {
+		t.Fatalf("commission_bps = %q, want \"550\"", got)
+	}
+	if got := rewards[0].GetCommission(); got != "5" {
+		t.Fatalf("commission = %q, want \"5\"", got)
+	}
+	if rewards[0].GetRewardType() != pb.RewardType_Voting {
+		t.Fatalf("reward_type = %v, want Voting", rewards[0].GetRewardType())
+	}
+
+	// Reward without commission: empty string on the wire
+	if got := rewards[1].GetCommissionBps(); got != "" {
+		t.Fatalf("commission_bps = %q, want empty", got)
+	}
+}

--- a/javascript/Cargo.lock
+++ b/javascript/Cargo.lock
@@ -793,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "laserstream-core-proto"
-version = "11.1.0"
+version = "11.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ac4a3743baa7a34a548a990b838d0db7c3e50bb614e7aedbd18443617cfc59"
+checksum = "3cc5910f46e50b538e6d9ae5eb573bbf83861fe223a5ce30c914f1822a60602d"
 dependencies = [
  "anyhow",
  "prost 0.14.4",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "laserstream-napi"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "base64 0.21.7",
  "bs58",

--- a/javascript/Cargo.toml
+++ b/javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laserstream-napi"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 
 [lib]
@@ -24,7 +24,7 @@ futures-channel = "0.3"
 parking_lot = "0.12"
 uuid = { version = "1", features = ["v4"] }
 laserstream-core-client = "11.1.0"
-laserstream-core-proto = { version = "11.1.0", default-features = false, features = ["tonic", "tonic-compression"] }
+laserstream-core-proto = { version = "11.2.0", default-features = false, features = ["tonic", "tonic-compression"] }
 prost = "0.14"
 bs58 = "0.5.0"
 fastrand = "2.0"

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "helius-laserstream",
-  "version": "0.7.0",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "helius-laserstream",
-      "version": "0.7.0",
+      "version": "0.8.4",
       "cpu": [
         "x64",
         "arm64"
@@ -35,12 +35,12 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "helius-laserstream-darwin-arm64": "0.7.0",
-        "helius-laserstream-darwin-x64": "0.7.0",
-        "helius-laserstream-linux-arm64-gnu": "0.7.0",
-        "helius-laserstream-linux-arm64-musl": "0.7.0",
-        "helius-laserstream-linux-x64-gnu": "0.7.0",
-        "helius-laserstream-linux-x64-musl": "0.7.0"
+        "helius-laserstream-darwin-arm64": "0.8.4",
+        "helius-laserstream-darwin-x64": "0.8.4",
+        "helius-laserstream-linux-arm64-gnu": "0.8.4",
+        "helius-laserstream-linux-arm64-musl": "0.8.4",
+        "helius-laserstream-linux-x64-gnu": "0.8.4",
+        "helius-laserstream-linux-x64-musl": "0.8.4"
       }
     },
     "node_modules/@babel/runtime": {
@@ -877,84 +877,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/helius-laserstream-darwin-arm64": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/helius-laserstream-darwin-arm64/-/helius-laserstream-darwin-arm64-0.7.0.tgz",
-      "integrity": "sha512-DAE8D5B7JyOu4yKLQsWAF4QCfWYqGldT3pzf8xx2WFrMAs0MKcmMigzjIOHS+AWupopjeu9+e/9ZkwbP5pKZDg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/helius-laserstream-darwin-x64": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/helius-laserstream-darwin-x64/-/helius-laserstream-darwin-x64-0.7.0.tgz",
-      "integrity": "sha512-olHF556dfrp96R8KD3Jnk65/DZ5TDEmxXyiogKQfXTQFt5uweq/ID3BxfrmaPS4aH4fye53fET/mkwocN9E4ag==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/helius-laserstream-linux-arm64-gnu": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/helius-laserstream-linux-arm64-gnu/-/helius-laserstream-linux-arm64-gnu-0.7.0.tgz",
-      "integrity": "sha512-VbhV6RTp6uCfit2S5dL+YUHl/qjv0mdcOJVswcvMT1mw35WFPZqLdaINQ/P2fMZmEQlJyWQAYKJWwdRHezFMag==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/helius-laserstream-linux-arm64-musl": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/helius-laserstream-linux-arm64-musl/-/helius-laserstream-linux-arm64-musl-0.7.0.tgz",
-      "integrity": "sha512-B1Y1X2f3QwT8kahGafXPpgQG0v6gC971+povz0Gec2PhP8fObg120+DYGCrWBqL9WE0ItyifTM7FeihE25R+dw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/helius-laserstream-linux-x64-gnu": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/helius-laserstream-linux-x64-gnu/-/helius-laserstream-linux-x64-gnu-0.7.0.tgz",
-      "integrity": "sha512-9AzxbcAITAk5uoRM8Ih3i5YpwyK/ua6SMX7Em1rn49FSDpXMXWNoIqm16KOHUD3cVf+7QvXZfuc/6Jkrz9T4SQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/helius-laserstream-linux-x64-musl": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/helius-laserstream-linux-x64-musl/-/helius-laserstream-linux-x64-musl-0.7.0.tgz",
-      "integrity": "sha512-KZmcQGWZf0w9vn8rjguL9gecyzPfUbj1MSasMKmnuy8qTNgoZ0D8O5gkXndgDhttVlABSJLLbtfQX/UqFEXxSw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
     },
     "node_modules/humanize-ms": {
       "version": "1.2.1",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helius-laserstream",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "High-performance Laserstream gRPC client with automatic reconnection",
   "main": "client.js",
   "types": "client.d.ts",
@@ -37,6 +37,7 @@
     "example:preprocessed-transaction-sub": "ts-node examples/preprocessed-transaction-sub.ts",
     "example:preprocessed-filters-test": "ts-node examples/preprocessed-filters-test.ts",
     "test:cuckoo": "node test/cuckoo-vectors.test.js",
+    "test:v1-config": "node test/v1-config-vectors.test.js",
     "test:cuckoo-e2e": "node test/cuckoo-e2e-thorough.js",
     "perf:test": "ts-node performance/pump-raydium-performance-test.ts",
     "perf:slot": "ts-node performance/slot-performance-test.ts",
@@ -92,12 +93,12 @@
     }
   },
   "optionalDependencies": {
-    "helius-laserstream-darwin-arm64": "0.8.3",
-    "helius-laserstream-darwin-x64": "0.8.3",
-    "helius-laserstream-linux-arm64-gnu": "0.8.3",
-    "helius-laserstream-linux-arm64-musl": "0.8.3",
-    "helius-laserstream-linux-x64-gnu": "0.8.3",
-    "helius-laserstream-linux-x64-musl": "0.8.3"
+    "helius-laserstream-darwin-arm64": "0.8.4",
+    "helius-laserstream-darwin-x64": "0.8.4",
+    "helius-laserstream-linux-arm64-gnu": "0.8.4",
+    "helius-laserstream-linux-arm64-musl": "0.8.4",
+    "helius-laserstream-linux-x64-gnu": "0.8.4",
+    "helius-laserstream-linux-x64-musl": "0.8.4"
   },
   "dependencies": {
     "laserstream-core-proto-js": "^9.0.2",

--- a/javascript/test/v1-config-vectors.test.js
+++ b/javascript/test/v1-config-vectors.test.js
@@ -1,0 +1,66 @@
+/**
+ * Regression vectors for V1 transaction config (SIMD-0385) and
+ * Reward.commissionBps (SIMD-0291).
+ *
+ * The base64 payloads are SubscribeUpdate messages encoded with
+ * laserstream-core-proto 11.2.0 (Rust/prost) — the same bytes are asserted
+ * against the Go and Rust SDKs, so all three decode identically.
+ *
+ * Run: npm run test:v1-config
+ */
+
+const assert = require('assert');
+const { initProtobuf, decodeSubscribeUpdate } = require('../proto-decoder');
+
+// SubscribeUpdate{transaction} whose message carries TransactionConfig
+const V1_CONFIG_TX = 'CgR2ZWMxIpUCCowCCkAHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHGsMBCkAHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHEn8KBAgBGAISIAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBEiACAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAhogCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkoAToPCJS05PTLAxDAuVUggIAQIgAoKhC72ZGsAQ==';
+// SubscribeUpdate{block} whose rewards carry commissionBps
+const COMMISSION_BPS_BLOCK = 'CgR2ZWMyKoYBCLzZkawBEgR0ZXN0GngKPgorVm90ZTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMRCIJxigjQYgBCoBNTIDNTUwCjYKK1N0YWtlMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEQj04YwJoMIAM=';
+
+async function main() {
+  await initProtobuf();
+
+  // --- Vector 1: V1 transaction message with config ---
+  const txUpdate = decodeSubscribeUpdate(Buffer.from(V1_CONFIG_TX, 'base64'));
+  assert.ok(txUpdate.transaction, 'expected transaction update');
+  assert.strictEqual(txUpdate.transaction.slot, '361000123');
+
+  const msg = txUpdate.transaction.transaction.transaction.message;
+  assert.strictEqual(msg.versioned, true);
+  assert.ok(msg.config, 'expected message.config to be present for V1');
+  assert.strictEqual(msg.config.priorityFee, '123456789012');
+  assert.strictEqual(msg.config.computeUnitLimit, 1400000);
+  assert.strictEqual(msg.config.heapSize, 262144);
+  // Unset optional field must not be reported as present
+  assert.ok(
+    msg.config.loadedAccountsDataSizeLimit === undefined ||
+      msg.config.loadedAccountsDataSizeLimit === null,
+    'loadedAccountsDataSizeLimit must be absent'
+  );
+
+  // Legacy/V0-shaped messages must NOT grow a config
+  const header = msg.header;
+  assert.ok(header && header.numRequiredSignatures === 1);
+
+  // --- Vector 2: block rewards with commissionBps ---
+  const blockUpdate = decodeSubscribeUpdate(Buffer.from(COMMISSION_BPS_BLOCK, 'base64'));
+  assert.ok(blockUpdate.block, 'expected block update');
+  const rewards = blockUpdate.block.rewards.rewards;
+  assert.strictEqual(rewards.length, 2);
+
+  assert.strictEqual(rewards[0].pubkey, 'Vote111111111111111111111111111111111111111');
+  assert.strictEqual(rewards[0].commission, '5');
+  assert.strictEqual(rewards[0].commissionBps, '550');
+  assert.strictEqual(rewards[0].rewardType, 4); // Voting
+
+  // Second reward has no commission at all — empty string on the wire
+  assert.strictEqual(rewards[1].commissionBps, '');
+  assert.strictEqual(rewards[1].rewardType, 3); // Staking
+
+  console.log('✅ v1-config vectors: all assertions passed');
+}
+
+main().catch((err) => {
+  console.error('❌ v1-config vectors failed:', err.message);
+  process.exit(1);
+});

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1044,7 +1044,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helius-laserstream"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-stream",
  "bs58",
@@ -1458,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "laserstream-core-proto"
-version = "11.1.0"
+version = "11.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ac4a3743baa7a34a548a990b838d0db7c3e50bb614e7aedbd18443617cfc59"
+checksum = "3cc5910f46e50b538e6d9ae5eb573bbf83861fe223a5ce30c914f1822a60602d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1470,10 +1470,14 @@ dependencies = [
  "siphasher",
  "solana-account 4.3.1",
  "solana-account-decoder",
+ "solana-address 2.6.1",
  "solana-clock",
  "solana-hash",
+ "solana-instruction-error",
  "solana-message",
  "solana-pubkey 4.2.0",
+ "solana-reward-info",
+ "solana-short-vec",
  "solana-signature",
  "solana-transaction",
  "solana-transaction-context",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helius-laserstream"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 authors = ["Helius <support@helius.xyz>"]
 description = "Rust client for Helius LaserStream gRPC with robust reconnection and slot tracking"
@@ -12,7 +12,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-laserstream-core-proto = { version = "11.1.0", default-features = false, features = ["tonic", "tonic-compression"] }
+laserstream-core-proto = { version = "11.2.0", default-features = false, features = ["tonic", "tonic-compression"] }
 # Pin proto + client together: the client bundles its own proto, so a mismatched
 # version would make `SubscribeRequest` a distinct type from the client's API.
 laserstream-core-client = "11.1.0"

--- a/rust/tests/v1_config_vectors.rs
+++ b/rust/tests/v1_config_vectors.rs
@@ -1,0 +1,83 @@
+//! Regression vectors for V1 transaction config (SIMD-0385) and
+//! Reward.commission_bps (SIMD-0291).
+//!
+//! The base64 payloads are SubscribeUpdate messages encoded with
+//! laserstream-core-proto 11.2.0 — the same bytes are asserted against the
+//! JS and Go SDKs, so all three decode identically.
+
+use helius_laserstream::grpc::{subscribe_update::UpdateOneof, SubscribeUpdate};
+// Use the prost version the proto types were generated with (re-exported by
+// the core proto crate), not the SDK's own direct prost dependency.
+use laserstream_core_proto::prost::Message as _;
+
+/// SubscribeUpdate{transaction} whose message carries TransactionConfig
+const V1_CONFIG_TX_B64: &str = "CgR2ZWMxIpUCCowCCkAHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHGsMBCkAHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHEn8KBAgBGAISIAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBEiACAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAhogCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkoAToPCJS05PTLAxDAuVUggIAQIgAoKhC72ZGsAQ==";
+/// SubscribeUpdate{block} whose rewards carry commission_bps
+const COMMISSION_BPS_BLOCK_B64: &str = "CgR2ZWMyKoYBCLzZkawBEgR0ZXN0GngKPgorVm90ZTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMRCIJxigjQYgBCoBNTIDNTUwCjYKK1N0YWtlMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEQj04YwJoMIAM=";
+
+fn decode(b64: &str) -> SubscribeUpdate {
+    let raw = b64_decode(b64);
+    SubscribeUpdate::decode(raw.as_slice()).expect("decode SubscribeUpdate")
+}
+
+/// Minimal std-only base64 decode so the test needs no extra dev-dependency.
+fn b64_decode(s: &str) -> Vec<u8> {
+    const TABLE: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = Vec::with_capacity(s.len() * 3 / 4);
+    let mut buf = 0u32;
+    let mut bits = 0u32;
+    for &c in s.as_bytes() {
+        if c == b'=' {
+            break;
+        }
+        let v = TABLE.iter().position(|&t| t == c).expect("valid base64") as u32;
+        buf = (buf << 6) | v;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push((buf >> bits) as u8);
+        }
+    }
+    out
+}
+
+#[test]
+fn v1_transaction_config_decodes() {
+    let update = decode(V1_CONFIG_TX_B64);
+    let Some(UpdateOneof::Transaction(tx)) = update.update_oneof else {
+        panic!("expected transaction update");
+    };
+    assert_eq!(tx.slot, 361_000_123);
+
+    let msg = tx
+        .transaction
+        .expect("tx info")
+        .transaction
+        .expect("tx")
+        .message
+        .expect("message");
+    assert!(msg.versioned);
+
+    let config = msg.config.expect("message.config present for V1");
+    assert_eq!(config.priority_fee, Some(123_456_789_012));
+    assert_eq!(config.compute_unit_limit, Some(1_400_000));
+    assert_eq!(config.heap_size, Some(262_144));
+    assert_eq!(config.loaded_accounts_data_size_limit, None);
+}
+
+#[test]
+fn reward_commission_bps_decodes() {
+    let update = decode(COMMISSION_BPS_BLOCK_B64);
+    let Some(UpdateOneof::Block(block)) = update.update_oneof else {
+        panic!("expected block update");
+    };
+    let rewards = block.rewards.expect("rewards").rewards;
+    assert_eq!(rewards.len(), 2);
+
+    assert_eq!(rewards[0].commission_bps, "550");
+    assert_eq!(rewards[0].commission, "5");
+    assert_eq!(rewards[0].reward_type, 4); // Voting
+
+    // Reward without commission: empty string on the wire
+    assert_eq!(rewards[1].commission_bps, "");
+}


### PR DESCRIPTION
Follow-up to #112: makes the V1 transaction config (SIMD-0385) and `Reward.commission_bps` (SIMD-0291) available across all three SDKs and locks the wire behavior with tests.

## Changes

- **Rust SDK → 0.6.3** on `laserstream-core-proto` **11.2.0** (published from fork PR helius-labs/yellowstone-grpc#48). Rust consumers now see `Message.config` / `TransactionConfig` and `Reward.commission_bps` in decoded updates, and `convert_from::create_message` reconstructs `VersionedMessage::V1` (previously downgraded to V0 — the rpcpool/yellowstone-grpc#855 fix).
- **JS SDK → 0.8.4**: napi transport pinned to core-proto 11.2.0. (The napi layer uses a raw-bytes codec and the bundled `.proto` shipped in 0.8.3, so runtime behavior was already correct — this aligns the pinned crate and adds the regression test. TS types for the new fields land via `laserstream-core-proto-js` 9.1.0, resolved by the existing `^9.0.2` range.)
- **Go SDK**: already had the fields from #112 (released as `go/v0.1.5`); gains the regression test.

## Testing

- **Cross-SDK golden vectors**: two `SubscribeUpdate` payloads (a V1 transaction with `TransactionConfig` incl. an unset optional field, and block rewards with/without `commission_bps`) encoded once with core-proto 11.2.0, asserted byte-identically in all three SDKs:
  - `go test -run 'V1TransactionConfig|RewardCommissionBps'` — 2/2 pass
  - `cargo test --test v1_config_vectors` — 2/2 pass
  - `npm run test:v1-config` (exercises the real `proto-decoder` path) — pass
- **Regression suites**: full Go package tests, `npm run test:cuckoo` (11/11), Rust SDK builds + tests green.
- **Live smokes** (mainnet TYO, 20s each): Go 19.7k txns/46 blocks, JS (fresh napi build) 20k txns/44 blocks, Rust `transaction_sub` example streaming with `config: None` visible in decoded structs. `v1Config=0, commissionBps=0` observed — expected until V1 transactions exist on mainnet and the server-side change deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)