### PR TITLE
Expose the match_mints transaction-filter flag (subscribe by mint)

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -176,6 +176,31 @@ req := &laserstream.SubscribeRequest{
 
 See [`examples/token-accounts-sub.go`](./examples/token-accounts-sub.go).
 
+#### MatchMints (subscribe by token mint)
+
+Set `MatchMints: true` so `AccountInclude` / `AccountExclude` /
+`AccountRequired` also match against the **mints of pre/post token balances**.
+Put mints in `AccountInclude` to stream every transaction touching those
+tokens — including classic SPL `Transfer`s, whose account keys never contain
+the mint (an account-key filter alone misses them).
+
+```go
+vote := false
+failed := false
+req := &laserstream.SubscribeRequest{
+    Transactions: map[string]*laserstream.SubscribeRequestFilterTransactions{
+        "usdc-txs": {
+            // USDC mint
+            AccountInclude: []string{"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"},
+            Vote:           &vote,
+            Failed:         &failed,
+            MatchMints:     true,
+        },
+    },
+    Commitment: &commitmentLevel,
+}
+```
+
 ### Block Subscriptions
 ```go
 includeTransactions := true

--- a/go/proto/geyser.pb.go
+++ b/go/proto/geyser.pb.go
@@ -1138,7 +1138,7 @@ type SubscribeRequestFilterTransactions struct {
 	// against owners of pre/post token balances on each transaction.
 	// Absent = no expansion.
 	TokenAccounts *TokenAccountExpansionControlFlag `protobuf:"varint,30,opt,name=token_accounts,json=tokenAccounts,proto3,enum=geyser.TokenAccountExpansionControlFlag,oneof" json:"token_accounts,omitempty"`
-	// Helius extension: also match the account lists against pre/post token-balance mints.
+	// Also match the account lists against pre/post token-balance mints.
 	MatchMints    bool `protobuf:"varint,32,opt,name=match_mints,json=matchMints,proto3" json:"match_mints,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/go/proto/geyser.pb.go
+++ b/go/proto/geyser.pb.go
@@ -1138,9 +1138,7 @@ type SubscribeRequestFilterTransactions struct {
 	// against owners of pre/post token balances on each transaction.
 	// Absent = no expansion.
 	TokenAccounts *TokenAccountExpansionControlFlag `protobuf:"varint,30,opt,name=token_accounts,json=tokenAccounts,proto3,enum=geyser.TokenAccountExpansionControlFlag,oneof" json:"token_accounts,omitempty"`
-	// Helius extension: when true, account_include / account_exclude /
-	// account_required also match against the mints of pre/post token balances.
-	// Catches classic SPL `Transfer`s, whose keys never contain the mint.
+	// Helius extension: also match the account lists against pre/post token-balance mints.
 	MatchMints    bool `protobuf:"varint,32,opt,name=match_mints,json=matchMints,proto3" json:"match_mints,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/go/proto/geyser.pb.go
+++ b/go/proto/geyser.pb.go
@@ -1138,6 +1138,10 @@ type SubscribeRequestFilterTransactions struct {
 	// against owners of pre/post token balances on each transaction.
 	// Absent = no expansion.
 	TokenAccounts *TokenAccountExpansionControlFlag `protobuf:"varint,30,opt,name=token_accounts,json=tokenAccounts,proto3,enum=geyser.TokenAccountExpansionControlFlag,oneof" json:"token_accounts,omitempty"`
+	// Helius extension: when true, account_include / account_exclude /
+	// account_required also match against the mints of pre/post token balances.
+	// Catches classic SPL `Transfer`s, whose keys never contain the mint.
+	MatchMints    bool `protobuf:"varint,32,opt,name=match_mints,json=matchMints,proto3" json:"match_mints,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1219,6 +1223,13 @@ func (x *SubscribeRequestFilterTransactions) GetTokenAccounts() TokenAccountExpa
 		return *x.TokenAccounts
 	}
 	return TokenAccountExpansionControlFlag_ALL
+}
+
+func (x *SubscribeRequestFilterTransactions) GetMatchMints() bool {
+	if x != nil {
+		return x.MatchMints
+	}
+	return false
 }
 
 type SubscribeRequestFilterBlocks struct {
@@ -3294,7 +3305,7 @@ const file_geyser_proto_rawDesc = "" +
 	"\x14filter_by_commitment\x18\x01 \x01(\bH\x00R\x12filterByCommitment\x88\x01\x01\x120\n" +
 	"\x11interslot_updates\x18\x02 \x01(\bH\x01R\x10interslotUpdates\x88\x01\x01B\x17\n" +
 	"\x15_filter_by_commitmentB\x14\n" +
-	"\x12_interslot_updates\"\x85\x03\n" +
+	"\x12_interslot_updates\"\xa6\x03\n" +
 	"\"SubscribeRequestFilterTransactions\x12\x17\n" +
 	"\x04vote\x18\x01 \x01(\bH\x00R\x04vote\x88\x01\x01\x12\x1b\n" +
 	"\x06failed\x18\x02 \x01(\bH\x01R\x06failed\x88\x01\x01\x12!\n" +
@@ -3302,7 +3313,9 @@ const file_geyser_proto_rawDesc = "" +
 	"\x0faccount_include\x18\x03 \x03(\tR\x0eaccountInclude\x12'\n" +
 	"\x0faccount_exclude\x18\x04 \x03(\tR\x0eaccountExclude\x12)\n" +
 	"\x10account_required\x18\x06 \x03(\tR\x0faccountRequired\x12T\n" +
-	"\x0etoken_accounts\x18\x1e \x01(\x0e2(.geyser.TokenAccountExpansionControlFlagH\x03R\rtokenAccounts\x88\x01\x01B\a\n" +
+	"\x0etoken_accounts\x18\x1e \x01(\x0e2(.geyser.TokenAccountExpansionControlFlagH\x03R\rtokenAccounts\x88\x01\x01\x12\x1f\n" +
+	"\vmatch_mints\x18  \x01(\bR\n" +
+	"matchMintsB\a\n" +
 	"\x05_voteB\t\n" +
 	"\a_failedB\f\n" +
 	"\n" +

--- a/go/proto/geyser.proto
+++ b/go/proto/geyser.proto
@@ -136,7 +136,7 @@ message SubscribeRequestFilterTransactions {
   // against owners of pre/post token balances on each transaction.
   // Absent = no expansion.
   optional TokenAccountExpansionControlFlag token_accounts = 30;
-  // Helius extension: also match the account lists against pre/post token-balance mints.
+  // Also match the account lists against pre/post token-balance mints.
   bool match_mints = 32;
 }
 

--- a/go/proto/geyser.proto
+++ b/go/proto/geyser.proto
@@ -136,6 +136,10 @@ message SubscribeRequestFilterTransactions {
   // against owners of pre/post token balances on each transaction.
   // Absent = no expansion.
   optional TokenAccountExpansionControlFlag token_accounts = 30;
+  // Helius extension: when true, account_include / account_exclude /
+  // account_required also match against the mints of pre/post token balances.
+  // Catches classic SPL `Transfer`s, whose keys never contain the mint.
+  bool match_mints = 32;
 }
 
 // Helius extension: discriminator for `SubscribeRequestFilterTransactions.token_accounts`.

--- a/go/proto/geyser.proto
+++ b/go/proto/geyser.proto
@@ -136,9 +136,7 @@ message SubscribeRequestFilterTransactions {
   // against owners of pre/post token balances on each transaction.
   // Absent = no expansion.
   optional TokenAccountExpansionControlFlag token_accounts = 30;
-  // Helius extension: when true, account_include / account_exclude /
-  // account_required also match against the mints of pre/post token balances.
-  // Catches classic SPL `Transfer`s, whose keys never contain the mint.
+  // Helius extension: also match the account lists against pre/post token-balance mints.
   bool match_mints = 32;
 }
 

--- a/go/proto/match_mints_test.go
+++ b/go/proto/match_mints_test.go
@@ -1,0 +1,75 @@
+package proto
+
+import (
+	"bytes"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// Wire-format conformance for the Helius `match_mints` extension
+// (SubscribeRequestFilterTransactions field #32, bool). The expected bytes
+// must match what the Rust and JS SDKs emit for the same filter: tag
+// 0x80 0x02 (field 32, varint) followed by 0x01.
+func TestMatchMintsWireFormat(t *testing.T) {
+	f := &SubscribeRequestFilterTransactions{MatchMints: true}
+	got, err := proto.Marshal(f)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := []byte{0x80, 0x02, 0x01}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("marshal(match_mints=true) = %x, want %x", got, want)
+	}
+}
+
+// False (the default) must stay absent on the wire so existing subscribers
+// are byte-identical, and true must survive a marshal/unmarshal roundtrip.
+func TestMatchMintsPresence(t *testing.T) {
+	unset, err := proto.Marshal(&SubscribeRequestFilterTransactions{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if len(unset) != 0 {
+		t.Fatalf("default filter marshaled to %x, want empty", unset)
+	}
+
+	data, err := proto.Marshal(&SubscribeRequestFilterTransactions{MatchMints: true})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back SubscribeRequestFilterTransactions
+	if err := proto.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !back.GetMatchMints() {
+		t.Fatal("roundtrip lost match_mints=true")
+	}
+}
+
+// The flag must coexist with the rest of the filter and survive proto.Clone,
+// which the SDK uses internally for reconnect/replay requests.
+func TestMatchMintsCloneAndFullFilter(t *testing.T) {
+	vote, failed := false, false
+	f := &SubscribeRequestFilterTransactions{
+		Vote:           &vote,
+		Failed:         &failed,
+		AccountInclude: []string{"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"},
+		MatchMints:     true,
+	}
+	clone := proto.Clone(f).(*SubscribeRequestFilterTransactions)
+	if !clone.GetMatchMints() {
+		t.Fatal("clone lost match_mints")
+	}
+	data, err := proto.Marshal(f)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back SubscribeRequestFilterTransactions
+	if err := proto.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !proto.Equal(f, &back) {
+		t.Fatalf("roundtrip mismatch: %v vs %v", f, &back)
+	}
+}

--- a/javascript/Cargo.lock
+++ b/javascript/Cargo.lock
@@ -793,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "laserstream-core-proto"
-version = "11.2.0"
+version = "11.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc5910f46e50b538e6d9ae5eb573bbf83861fe223a5ce30c914f1822a60602d"
+checksum = "90653632d67d7784b62c59fa941f34e130d92598c8fbaeb028bff22143f5a16b"
 dependencies = [
  "anyhow",
  "prost 0.14.4",

--- a/javascript/Cargo.toml
+++ b/javascript/Cargo.toml
@@ -24,7 +24,7 @@ futures-channel = "0.3"
 parking_lot = "0.12"
 uuid = { version = "1", features = ["v4"] }
 laserstream-core-client = "11.1.0"
-laserstream-core-proto = { version = "11.2.0", default-features = false, features = ["tonic", "tonic-compression"] }
+laserstream-core-proto = { version = "11.3.0", default-features = false, features = ["tonic", "tonic-compression"] }
 prost = "0.14"
 bs58 = "0.5.0"
 fastrand = "2.0"

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -172,6 +172,30 @@ const request = {
 
 See [`examples/token-accounts-sub.ts`](./examples/token-accounts-sub.ts).
 
+#### matchMints (subscribe by token mint)
+
+Set `matchMints: true` so `accountInclude` / `accountExclude` /
+`accountRequired` also match against the **mints of pre/post token balances**.
+Put mints in `accountInclude` to stream every transaction touching those
+tokens — including classic SPL `Transfer`s, whose account keys never contain
+the mint (an account-key filter alone misses them).
+
+```typescript
+const request = {
+  transactions: {
+    "usdc-txs": {
+      accountInclude: ["EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"], // USDC mint
+      accountExclude: [],
+      accountRequired: [],
+      vote: false,
+      failed: false,
+      matchMints: true,
+    },
+  },
+  commitment: CommitmentLevel.CONFIRMED,
+};
+```
+
 ### Block Subscriptions
 ```typescript
 const request = {

--- a/javascript/client.d.ts
+++ b/javascript/client.d.ts
@@ -149,6 +149,14 @@ declare module 'laserstream-core-proto-js/generated' {
        * Built client-side via {@link CompressedAccountFilterSet.toTransactionFilter}.
        */
       cuckooAccountInclude?: (import('./cuckoo').CuckooFilterProto | null);
+      /**
+       * Helius mint matching (proto field #32). When true, `accountInclude` /
+       * `accountExclude` / `accountRequired` also match against the mints of
+       * pre/post token balances — catches classic SPL `Transfer`s, whose
+       * account keys never contain the mint. Put mints in `accountInclude`
+       * to stream every transaction touching those tokens.
+       */
+      matchMints?: (boolean | null);
     }
     interface ISubscribeRequestFilterAccounts {
       /**

--- a/javascript/napi-src/client.rs
+++ b/javascript/napi-src/client.rs
@@ -182,6 +182,10 @@ pub struct JsTransactionFilter {
     // Cuckoo filter over accountInclude (proto field #31), built client-side.
     #[serde(alias = "cuckooAccountInclude")]
     pub cuckoo_account_include: Option<JsCuckooFilter>,
+    // Helius mint matching (proto field #32): when true, the account lists
+    // also match against the mints of pre/post token balances.
+    #[serde(alias = "matchMints")]
+    pub match_mints: Option<bool>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -432,6 +436,8 @@ impl ClientInner {
                 yellowstone_filter.token_accounts = parse_token_accounts_mode(filter.token_accounts)
                     .map_err(Error::from_reason)?;
 
+                yellowstone_filter.match_mints = filter.match_mints.unwrap_or(false);
+
                 // Handle compressed account (cuckoo) filter — pass through bytes built client-side.
                 if let Some(cuckoo) = filter.cuckoo_account_include {
                     let data = general_purpose::STANDARD.decode(&cuckoo.data)
@@ -477,6 +483,8 @@ impl ClientInner {
 
                 yellowstone_filter.token_accounts = parse_token_accounts_mode(filter.token_accounts)
                     .map_err(Error::from_reason)?;
+
+                yellowstone_filter.match_mints = filter.match_mints.unwrap_or(false);
 
                 transactions_status_map.insert(key, yellowstone_filter);
             }

--- a/javascript/proto/geyser.proto
+++ b/javascript/proto/geyser.proto
@@ -147,7 +147,7 @@ message SubscribeRequestFilterTransactions {
   // against owners of pre/post token balances on each transaction.
   // Absent = no expansion.
   optional TokenAccountExpansionControlFlag token_accounts = 30;
-  // Helius extension: also match the account lists against pre/post token-balance mints.
+  // Also match the account lists against pre/post token-balance mints.
   bool match_mints = 32;
 }
 

--- a/javascript/proto/geyser.proto
+++ b/javascript/proto/geyser.proto
@@ -147,6 +147,10 @@ message SubscribeRequestFilterTransactions {
   // against owners of pre/post token balances on each transaction.
   // Absent = no expansion.
   optional TokenAccountExpansionControlFlag token_accounts = 30;
+  // Helius extension: when true, account_include / account_exclude /
+  // account_required also match against the mints of pre/post token balances.
+  // Catches classic SPL `Transfer`s, whose keys never contain the mint.
+  bool match_mints = 32;
 }
 
 // Helius extension: discriminator for `SubscribeRequestFilterTransactions.token_accounts`.

--- a/javascript/proto/geyser.proto
+++ b/javascript/proto/geyser.proto
@@ -147,9 +147,7 @@ message SubscribeRequestFilterTransactions {
   // against owners of pre/post token balances on each transaction.
   // Absent = no expansion.
   optional TokenAccountExpansionControlFlag token_accounts = 30;
-  // Helius extension: when true, account_include / account_exclude /
-  // account_required also match against the mints of pre/post token balances.
-  // Catches classic SPL `Transfer`s, whose keys never contain the mint.
+  // Helius extension: also match the account lists against pre/post token-balance mints.
   bool match_mints = 32;
 }
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1458,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "laserstream-core-proto"
-version = "11.2.0"
+version = "11.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc5910f46e50b538e6d9ae5eb573bbf83861fe223a5ce30c914f1822a60602d"
+checksum = "90653632d67d7784b62c59fa941f34e130d92598c8fbaeb028bff22143f5a16b"
 dependencies = [
  "anyhow",
  "bincode",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-laserstream-core-proto = { version = "11.2.0", default-features = false, features = ["tonic", "tonic-compression"] }
+laserstream-core-proto = { version = "11.3.0", default-features = false, features = ["tonic", "tonic-compression"] }
 # Pin proto + client together: the client bundles its own proto, so a mismatched
 # version would make `SubscribeRequest` a distinct type from the client's API.
 laserstream-core-client = "11.1.0"

--- a/rust/README.md
+++ b/rust/README.md
@@ -186,6 +186,33 @@ let request = SubscribeRequest {
 
 See [`examples/token_accounts_filter.rs`](./examples/token_accounts_filter.rs).
 
+#### match_mints (subscribe by token mint)
+
+Set `match_mints: true` so `account_include` / `account_exclude` /
+`account_required` also match against the **mints of pre/post token balances**.
+Put mints in `account_include` to stream every transaction touching those
+tokens — including classic SPL `Transfer`s, whose account keys never contain
+the mint (an account-key filter alone misses them).
+
+```rust
+use helius_laserstream::grpc::{SubscribeRequest, SubscribeRequestFilterTransactions};
+
+let request = SubscribeRequest {
+    transactions: HashMap::from([(
+        "usdc-txs".to_string(),
+        SubscribeRequestFilterTransactions {
+            // USDC mint
+            account_include: vec!["EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string()],
+            vote: Some(false),
+            failed: Some(false),
+            match_mints: true,
+            ..Default::default()
+        },
+    )]),
+    ..Default::default()
+};
+```
+
 ### Block Subscriptions
 ```rust
 use helius_laserstream::grpc::{


### PR DESCRIPTION
## Summary

Exposes the new `match_mints` transaction-filter flag (proto field #32) in all three SDKs. When set, `account_include` / `account_exclude` / `account_required` also match against the mints of pre/post token balances — put mints in `account_include` to stream every transaction touching those tokens, including classic SPL `Transfer`s whose account keys never contain the mint.

Server side: helius-labs/monorepo#18758. Proto crate: helius-labs/yellowstone-grpc#50.

## Changes

- **Go** (self-contained, green now): field added to the vendored proto, `geyser.pb.go` regenerated with the repo's exact tool versions (protoc 29.3 / protoc-gen-go 1.36.10 — targeted +17/−2 diff), wire-format + presence + clone tests (`go test ./proto/ -run MatchMints` 3/3 pass), README section. No `laserstream.go` change needed — the filter type is an alias of the generated struct.
- **JS**: `matchMints` accepted on transaction and transactionsStatus filters in the napi layer (camelCase + snake_case aliases, defaults to false), `client.d.ts` type augmentation, bundled `.proto` updated, README section. Napi crate verified to compile against a local core-proto build carrying the field.
- **Rust**: `laserstream-core-proto` minimum bumped to 11.3.0 (the type comes straight from the proto crate, so no code change), README section.

## Sequencing (why draft)

`laserstream-core-proto` 11.3.0 doesn't exist yet — it publishes from helius-labs/yellowstone-grpc#50. Until then the JS/Rust legs can't resolve the dep, so CI will be red. Order: merge the proto PR → publish 11.3.0 → refresh `javascript/Cargo.lock` here → un-draft. Package version bumps (JS/Rust/Go tags) at release time as usual.

Also worth waiting for the server-side monorepo PR to deploy before releasing, so the flag doesn't no-op for users on older Laserstream versions.

Made with [Cursor](https://cursor.com)