### PR TITLE
SDK: publish hygiene — unyank chacha20, exclude Cargo.lock, fix flaky publish-verify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,16 +347,22 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           echo "🔍 Verifying publication of version $VERSION"
 
-          # npm reads are eventually consistent; retry briefly before failing
+          # npm reads are eventually consistent and the read CDN can lag a
+          # successful publish by a few minutes. Poll with a generous window
+          # (~4 min) and bypass the npm cache so we hit the registry directly;
+          # a too-short window here has red-flagged two already-successful
+          # releases (0.8.5, 0.9.0) even though publish succeeded.
           verify_package() {
-            for i in 1 2 3 4 5 6; do
-              if npm view "$1@$VERSION" version > /dev/null 2>&1; then
+            # initial grace period before the first check
+            sleep 15
+            for i in $(seq 1 24); do
+              if npm view "$1@$VERSION" version --prefer-online > /dev/null 2>&1; then
                 echo "✅ Verified: $1@$VERSION"
                 return 0
               fi
               sleep 10
             done
-            echo "❌ Error: Package $1@$VERSION not found on NPM"
+            echo "❌ Error: Package $1@$VERSION not found on NPM after ~4 min"
             return 1
           }
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,6 +8,9 @@ license = "MIT"
 repository = "https://github.com/helius-labs/laserstream"
 keywords = ["solana", "laserstream", "yellowstone", "grpc", "blockchain"]
 readme = "README.md"
+# A library should not ship its Cargo.lock — consumers ignore it and it only
+# goes stale in the published artifact.
+exclude = ["/Cargo.lock"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## Summary

Three publish-hygiene fixes surfaced during the `helius-laserstream 0.7.0` / npm `0.9.0` releases:

1. **Unyank `chacha20`** — the lockfile pinned `chacha20 0.10.1`, which is yanked on crates.io (`cargo publish` warned). Bumped to `0.10.2`.
2. **Stop shipping `Cargo.lock` in the published crate** — added `exclude = ["/Cargo.lock"]`. A library's lockfile is ignored by consumers and only goes stale in the published artifact. The lock stays **tracked in git** (the crate's `[[bin]]` integrity-test targets + CI still get a pinned lock); it's just excluded from the crates.io package.
3. **Fix the flaky npm publish-verify** — the `Verify publication` CI step re-queries the registry right after `npm publish`. Its 60s poll (6×10s) is shorter than npm's read-CDN propagation, so it has **red-flagged two already-successful releases** (0.8.5 and 0.9.0 both published fine but the workflow went red on verify). Widened to ~4 min (24×10s + 15s initial grace) and switched to `--prefer-online` to bypass the local cache. A red verify should mean a real failure, not propagation lag.

Version left at **0.7.0 / napi 0.9.0** — these affect the *next* publish, not the already-published releases.

## Verification
- `cargo package --list` no longer includes `Cargo.lock`; crate still packages cleanly.
- Verify-step change is CI-only (a shell loop widening); no runtime code touched.

Follow-up to the LS-271 SDK release.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>